### PR TITLE
Fix shared segment calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,4 @@ runtime_requires = [
     "qgis_plugin_tools",
     "segment-reshape-qgis-plugin"
 ]
+version_number_source = "distribution"

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ flake8-pie==0.14.0
 flake8-no-pep420==1.1.1
 
 # tools
-qgis-plugin-dev-tools==0.3.0
+qgis-plugin-dev-tools==0.4.0
 
 # NOTE: Runtime requirements for QGIS plugin are defined in setup.cfg
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -148,7 +148,7 @@ python-dotenv==0.21.0
     #   qgis-plugin-dev-tools
 pyyaml==6.0
     # via pre-commit
-qgis-plugin-dev-tools==0.3.0
+qgis-plugin-dev-tools==0.4.0
     # via -r requirements.in
 qgis-plugin-tools==0.2.0
     # via segment-reshape-qgis-plugin

--- a/src/segment_reshape/geometry/reshape.py
+++ b/src/segment_reshape/geometry/reshape.py
@@ -177,14 +177,23 @@ def _reshape_geometry(
                 )
 
     else:
-        # handle case when a full polygon is redrawn
+        # handle case when a full polygon is redrawn as closed
         if (
-            original.type() == QgsWkbTypes.GeometryType.PolygonGeometry
+            len(vertex_indices) > 1
+            and original.type() == QgsWkbTypes.GeometryType.PolygonGeometry
             and reshape_geometry.endPoint() == reshape_geometry.startPoint()
             and vertex_indices[0] == vertex_indices[-1]
         ):
             vertex_indices = vertex_indices[:-1]
             reshape_geometry = QgsLineString(list(reshape_geometry.vertices())[:-1])
+        # handle case when a full polygon is redrawn but not closed
+        elif (
+            len(vertex_indices) > 1
+            and original.type() == QgsWkbTypes.GeometryType.PolygonGeometry
+            and reshape_geometry.endPoint() != reshape_geometry.startPoint()
+            and vertex_indices[0] == vertex_indices[-1]
+        ):
+            vertex_indices = vertex_indices[:-1]
 
         # add vertices before the first replaced vertex
         min_vertex_index = min(vertex_indices)

--- a/src/segment_reshape/geometry/reshape.py
+++ b/src/segment_reshape/geometry/reshape.py
@@ -177,11 +177,13 @@ def _reshape_geometry(
                 )
 
     else:
-        # cleanup last in case a full polygon is redrawn
+        # handle case when a full polygon is redrawn
         if (
             original.type() == QgsWkbTypes.GeometryType.PolygonGeometry
             and reshape_geometry.endPoint() == reshape_geometry.startPoint()
+            and vertex_indices[0] == vertex_indices[-1]
         ):
+            vertex_indices = vertex_indices[:-1]
             reshape_geometry = QgsLineString(list(reshape_geometry.vertices())[:-1])
 
         # add vertices before the first replaced vertex

--- a/src/segment_reshape/topology/find_related.py
+++ b/src/segment_reshape/topology/find_related.py
@@ -137,17 +137,18 @@ def _get_containing_component(
 def _get_line_component_for_part_and_ring(
     geom: QgsGeometry, part_index: int, ring_index: int
 ) -> QgsGeometry:
-    for i, part in enumerate(geom.constParts()):
-        if i == part_index:
-            if isinstance(part, QgsPolygon):
-                if ring_index == 0:
-                    return QgsGeometry(part.exteriorRing().clone())
-                else:
-                    return QgsGeometry(part.interiorRing(ring_index - 1).clone())
-            else:
-                return QgsGeometry(part.clone())
-
-    raise ValueError(f"could not extract part {part_index} ring {ring_index} of {geom}")
+    try:
+        part = list(geom.constParts())[part_index]
+        if not isinstance(part, QgsPolygon):
+            return QgsGeometry(part.clone())
+        elif ring_index == 0:
+            return QgsGeometry(part.exteriorRing().clone())
+        else:
+            return QgsGeometry(part.interiorRing(ring_index - 1).clone())
+    except IndexError:
+        raise ValueError(
+            f"could not extract part {part_index} ring {ring_index} of {geom}"
+        )
 
 
 def _split_at_position(geom: QgsGeometry, position: QgsPoint) -> QgsGeometry:

--- a/src/segment_reshape/topology/find_related.py
+++ b/src/segment_reshape/topology/find_related.py
@@ -17,22 +17,23 @@
 #  You should have received a copy of the GNU General Public License
 #  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import List, Optional, Tuple
+from typing import Iterable, Iterator, List, Optional, Tuple, cast
 
 from qgis.core import (
     QgsFeature,
     QgsFeatureRequest,
     QgsGeometry,
     QgsLineString,
+    QgsMultiLineString,
     QgsPoint,
     QgsPointXY,
+    QgsPolygon,
     QgsProject,
     QgsVectorLayer,
     QgsWkbTypes,
 )
 
 from segment_reshape.geometry.reshape import ReshapeCommonPart, ReshapeEdge
-from segment_reshape.utils import clone_geometry_safely
 
 CommonGeometriesResult = Tuple[
     Optional[QgsLineString],
@@ -111,274 +112,66 @@ def find_related_features(
     ]
 
 
-def get_common_geometries(
-    main_feature_layer: QgsVectorLayer,
-    main_feature: QgsFeature,
-    related_features_by_layer: List[Tuple[QgsVectorLayer, QgsFeature]],
-    main_feature_segment: Tuple[int, int],
-) -> CommonGeometriesResult:
-
-    main_feature_geom = main_feature.geometry()
-    segment_start_point = clone_geometry_safely(
-        main_feature_geom.vertexAt(main_feature_segment[0])
-    )
-    segment_end_point = clone_geometry_safely(
-        main_feature_geom.vertexAt(main_feature_segment[1])
-    )
-
-    # Find geometries having their boundary intersecting main feature segment
-    common_segment_candidates: List[QgsGeometry] = []
-    for _, feature in related_features_by_layer:
-        geom = feature.geometry()
-        if (
-            geom.type() == QgsWkbTypes.GeometryType.PolygonGeometry
-            and (geom.touches(segment_start_point) and geom.touches(segment_end_point))
-        ) or (
-            geom.type() != QgsWkbTypes.GeometryType.PolygonGeometry
-            and (
-                geom.intersects(segment_start_point)
-                and geom.intersects(segment_end_point)
-            )
-        ):
-            common_segment_candidates.append(geom)
-
-    segments = []
-    end_points = []
-
-    common_segment_as_geom = QgsGeometry()
-    start_point = QgsPoint()
-    end_point = QgsPoint()
-
-    # Return just boundary as common segment if no candidates found
-    if len(common_segment_candidates) == 0:
-        if main_feature_geom.type() == QgsWkbTypes.GeometryType.PointGeometry:
-            return (None, [], [])
-
-        vertices = []
-        if main_feature_geom.type() == QgsWkbTypes.GeometryType.PolygonGeometry:
-            # TODO: multigeometries and holes in polygons
-            vertices = main_feature_geom.asPolygon()[0]
-
-        if main_feature_geom.type() == QgsWkbTypes.GeometryType.LineGeometry:
-            # TODO: multigeometries
-            vertices = main_feature_geom.asPolyline()
-
-        # TODO: How to handle common segments along the boundary
-        # (outside triggered segment)? Return just the boundary for now
-        return (
-            QgsLineString(vertices),
-            [
-                ReshapeCommonPart(
-                    main_feature_layer,
-                    main_feature,
-                    list(range(len(vertices))),
-                    is_reversed=False,
-                )
-            ],
-            [],
-        )
-
-    else:
-        common_segment = _calculate_common_segment(
-            main_feature_geom,
-            common_segment_candidates,
-            segment_start_point,
-            segment_end_point,
-        )
-
-        if common_segment is not None:
-            common_segment_as_geom = clone_geometry_safely(common_segment)
-            start_point = common_segment.startPoint()
-            end_point = common_segment.endPoint()
-
-    if common_segment is not None:
-        vertex_indices = _get_vertex_indices_of_segment(
-            main_feature_geom, common_segment_as_geom
-        )
-
-        segments.append(
-            ReshapeCommonPart(
-                main_feature_layer,
-                main_feature,
-                vertex_indices,
-                is_reversed=_check_if_vertices_are_reversed(vertex_indices),
-            )
-        )
-    else:
-        dist, vertex = main_feature_geom.closestVertexWithContext(
-            segment_start_point.asPoint()
-        )
-
-        if dist == 0:
-            end_points.append(
-                ReshapeEdge(main_feature_layer, main_feature, vertex, is_start=True)
-            )
-
-    for layer, feature in related_features_by_layer:
-        geom = feature.geometry()
-
-        # Features sharing common segment
-        if common_segment is not None and geom.contains(common_segment_as_geom):
-            vertex_indices = _get_vertex_indices_of_segment(
-                geom, common_segment_as_geom
-            )
-            segments.append(
-                ReshapeCommonPart(
-                    layer,
-                    feature,
-                    vertex_indices,
-                    is_reversed=_check_if_vertices_are_reversed(vertex_indices),
-                )
-            )
-
-        # Other features which may have vertex at segment end points
-        # or at trigger point location (in case common segment was not found)
+def _as_point_or_line_components(geom: QgsGeometry) -> Iterator[QgsGeometry]:
+    for part in geom.constParts():
+        if isinstance(part, QgsPolygon):
+            yield QgsGeometry(part.exteriorRing().clone())
+            for ring_index in range(part.numInteriorRings()):
+                yield QgsGeometry(part.interiorRing(ring_index).clone())
         else:
-            for point, is_start in [
-                (QgsPointXY(start_point), True),
-                (QgsPointXY(end_point), False),
-            ]:
-                dist, vertex = geom.closestVertexWithContext(point)
+            yield QgsGeometry(part.clone())
 
-                if dist == 0:
-                    end_points.append(
-                        ReshapeEdge(layer, feature, vertex, is_start=is_start)
-                    )
 
-    return (
-        QgsLineString(common_segment_as_geom.asPolyline())
-        if common_segment is not None
-        else None,
-        segments,
-        end_points,
+def _get_containing_component(
+    geom: QgsGeometry, contains_geom: QgsGeometry
+) -> QgsGeometry:
+    for component in _as_point_or_line_components(geom):
+        if component.contains(contains_geom):
+            return component
+
+    raise ValueError(
+        f"could not find component of {geom} that contains {contains_geom}"
     )
 
 
-def _calculate_common_segment(
-    main_geom: QgsGeometry,
-    geoms: List[QgsGeometry],
-    start_point: QgsGeometry,
-    end_point: QgsGeometry,
-) -> Optional[QgsLineString]:
-    """
-    Calculated shared segment of main geom and input geoms. Segment is shared when
-    all vertices matches at some part of one or more geometries. Function returns
-    common segment or None if resulting geometry is point or
-    no shared segment found.
-    """
-
-    intersection = clone_geometry_safely(main_geom)
-
-    # Calculate combined intersection
-    for geom in geoms:
-        temp_intersection = intersection.intersection(geom)
-        intersection = clone_geometry_safely(temp_intersection)
-
-    # Check that one of intersections matches at least one of tested
-    # geoms (main geom is checked later)
-    matches = []
-    for geom in geoms:
-        for part in intersection.constParts():
-            if isinstance(part, QgsLineString):
-                matches.append(_segment_matches_geom(geom, clone_geometry_safely(part)))
-
-    if not any(matches):
-        return None
-
-    common_segment_candidates = [
-        part.clone()
-        for part in intersection.constParts()
-        if isinstance(part, QgsLineString)
-    ]
-
-    # Find out which intersection is at trigger location
-    for candidate_line in common_segment_candidates:
-        candidate_geom = clone_geometry_safely(candidate_line)
-        if candidate_geom.intersects(start_point) and candidate_geom.intersects(
-            end_point
-        ):
-            if _segment_matches_geom(main_geom, candidate_geom):
-                return QgsLineString(candidate_geom.asPolyline())
+def _get_line_component_for_part_and_ring(
+    geom: QgsGeometry, part_index: int, ring_index: int
+) -> QgsGeometry:
+    for i, part in enumerate(geom.constParts()):
+        if i == part_index:
+            if isinstance(part, QgsPolygon):
+                if ring_index == 0:
+                    return QgsGeometry(part.exteriorRing().clone())
+                else:
+                    return QgsGeometry(part.interiorRing(ring_index - 1).clone())
             else:
-                # Common segment is not topologically correct (wrong end points)
-                return None
+                return QgsGeometry(part.clone())
 
-    # Return None in case intersection was a point or nothing found
-    return None
+    raise ValueError(f"could not extract part {part_index} ring {ring_index} of {geom}")
 
 
-def _segment_matches_geom(geom: QgsGeometry, candidate_geom: QgsGeometry) -> bool:
-    try:
-        _get_vertex_indices_of_segment(geom, candidate_geom)
-        return True
-    except ValueError:
-        return False
+def _split_at_position(geom: QgsGeometry, position: QgsPoint) -> QgsGeometry:
+    new = QgsMultiLineString()
+    collected = QgsLineString()
+    for vertex in geom.vertices():
+        collected.addVertex(vertex.clone())
+        if vertex == position:
+            if collected.vertexCount() > 1:
+                new.addGeometry(collected)
+            collected = QgsLineString([vertex.clone()])
+    if collected.vertexCount() > 1:
+        new.addGeometry(collected)
+    return QgsGeometry(new)
 
 
-def _get_vertex_indices_of_segment(
-    geom: QgsGeometry, segment_geom: QgsGeometry
-) -> List[int]:
-
-    polygon_start_point: Optional[QgsPoint] = None
-
-    if geom.type() == QgsWkbTypes.GeometryType.PolygonGeometry:
-        polygon_start_point = geom.asPolygon()[0][0]
-
-    vertex_indices = []
-    for i, point in enumerate(segment_geom.asPolyline()):
-        dist, vertex = geom.closestVertexWithContext(QgsPointXY(point))
-
-        if dist != 0:
-            raise ValueError("Segment did not match original geometry")
-
-        vertex_indices.append(vertex)
-        if i > 0 and abs(vertex_indices[i - 1] - vertex_indices[i]) != 1:
-            if polygon_start_point is not None:
-                previous_point = geom.vertexAt(vertex_indices[i - 1])
-                if abs(vertex_indices[i - 1] - vertex_indices[i]) == 0:
-                    vertex_indices[i] = 0
-                    continue
-                elif (
-                    point.x() == polygon_start_point.x()
-                    and point.y() == polygon_start_point.y()
-                ):
-                    vertex_indices[i] = 0
-                    continue
-                elif (
-                    previous_point.x() == polygon_start_point.x()
-                    and previous_point.y() == polygon_start_point.y()
-                ):
-                    vertex_indices[i - 1] = 0
-                    continue
-            raise ValueError("Segment did not match original geometry")
-
-    # Handle possible duplicates (applies to polygons only)
-    if (
-        geom.type() == QgsWkbTypes.GeometryType.PolygonGeometry
-        and vertex_indices.count(0) > 1
-    ):
-
-        # Find first instance of duplicate index
-        i = vertex_indices.index(0)
-
-        max_index = max(vertex_indices)
-
-        if i == 0:
-            vertex_indices[-1] = max_index
-
-        is_reversed = _check_if_vertices_are_reversed(vertex_indices)
-        if is_reversed is True:
-            # Replace second instance
-            vertex_indices = (
-                vertex_indices[: i + 1] + [max_index + 1] + vertex_indices[i + 2 :]
-            )
-        else:
-            # Replace fist instance
-            vertex_indices = (
-                vertex_indices[:i] + [max_index + 1] + vertex_indices[i + 1 :]
-            )
-
-    return vertex_indices
+def _find_vertex_indices(geom: QgsGeometry, positions: Iterable[QgsPoint]) -> List[int]:
+    indices: List[int] = []
+    for position in positions:
+        distance, vertex_index = geom.closestVertexWithContext(QgsPointXY(position))
+        if distance != 0:
+            raise ValueError(f"could not find vertex index for {position} from {geom}")
+        indices.append(vertex_index)
+    return indices
 
 
 def _check_if_vertices_are_reversed(vertex_indices: List[int]) -> bool:
@@ -389,3 +182,149 @@ def _check_if_vertices_are_reversed(vertex_indices: List[int]) -> bool:
             (abs(first - second) != 1 and first < second),
         ]
     )
+
+
+def get_common_geometries(
+    main_feature_layer: QgsVectorLayer,
+    main_feature: QgsFeature,
+    related_features_by_layer: List[Tuple[QgsVectorLayer, QgsFeature]],
+    main_feature_segment: Tuple[int, int],
+) -> CommonGeometriesResult:
+    # for now lines and polygons are supported as the trigger
+    if main_feature.geometry().type() not in [
+        QgsWkbTypes.GeometryType.LineGeometry,
+        QgsWkbTypes.GeometryType.PolygonGeometry,
+    ]:
+        raise ValueError(
+            f"unsupported source geometry type {main_feature.geometry().type()}"
+        )
+
+    from_vertex, to_vertex = main_feature_segment
+    trigger_geometry = main_feature.geometry()
+    trigger_segment = QgsGeometry.fromPolyline(
+        [
+            trigger_geometry.vertexAt(from_vertex).clone(),
+            trigger_geometry.vertexAt(to_vertex).clone(),
+        ]
+    )
+    success, to_vertex_id = trigger_geometry.vertexIdFromVertexNr(to_vertex)
+    if not success:
+        raise ValueError(
+            f"could not find vertex details by index {to_vertex}"
+            f" from {trigger_geometry}"
+        )
+
+    # start with the full line component as the result
+    result = _get_line_component_for_part_and_ring(
+        trigger_geometry, to_vertex_id.part, to_vertex_id.ring
+    )
+
+    common_part_candidates: List[Tuple[QgsVectorLayer, QgsFeature]] = []
+    possible_edge_candidates: List[Tuple[QgsVectorLayer, QgsFeature, QgsGeometry]] = []
+
+    for layer, feature in related_features_by_layer:
+        for component in _as_point_or_line_components(feature.geometry()):
+
+            # found a point which can only act as a break to the segment,
+            # split the result to multipart line at the point if possible
+            # -> collect as possible edge
+            if component.type() == QgsWkbTypes.GeometryType.PointGeometry:
+                result = _split_at_position(result, component.vertexAt(0))
+                possible_edge_candidates.append((layer, feature, component))
+
+            # found a line that shares the trigger segment, intersection to
+            # reduce the result to the part that is shared as common segment
+            # -> collect as common part
+            elif component.contains(trigger_segment):
+                # TODO: how to handle partial linear intersection where the
+                # component contains the trigger, but the containment is either
+                # within one longer segment or multiple shorter segments, and
+                # vertices will not match (same pair in same or reversed order)
+                result = result.intersection(component)
+                # intersection along multiple segments will return each segment
+                # as a separate part, merge parts here to keep the continuous line
+                if result.isMultipart():
+                    result = result.mergeLines()
+                common_part_candidates.append((layer, feature))
+
+            # found a line that may intersect along the result but not along
+            # trigger segment, cross or only touch the result, difference to reduce
+            # the result by removing parts of intersection along the result or
+            # by breaking the result to parts at the crossings or touch locations
+            # -> collect as possible edge
+            else:
+                # TODO: how to handle partial linear intersection where the result
+                # is reduced possibly even along the trigger segment, if the component
+                # has an vertex that falls along a segment of the result
+                # TODO: how to handle non-vertex touch/cross where the result will
+                # be split on the touching vertex or crossing segment even if there
+                # is no vertex on result
+                result = result.difference(component)
+                possible_edge_candidates.append((layer, feature, component))
+
+            # TODO: how to handle ring-like lines which may result in a split
+            # at a valid split point, and an existing split at the ring boundary,
+            # and after the split or difference operation we want to keep the
+            # continuous line around the boundary with with split or parts removed,
+            # since this conflicts with the points or difference operation results
+            # for crossing on touching lines which only result in breaks and will
+            # be rejoined if mergeLines is ran without special checks
+            # if result.isMultipart():
+            #     result = result.mergeLines()
+
+            # if result is now multipart due to the geometry operations,
+            # only keep the component which contains the trigger segment
+            # for polygon rings the two parts might overlap with
+            # the loop boundary, resulting in two continuous parts
+            if result.isMultipart():
+                result = _get_containing_component(result, trigger_segment)
+
+    # result is now the longest common combined segment available from the trigger
+    segment = cast(QgsLineString, result.constGet().clone())
+    start, end = QgsGeometry(segment.startPoint()), QgsGeometry(segment.endPoint())
+
+    common_parts: List[ReshapeCommonPart] = [
+        ReshapeCommonPart(
+            main_feature_layer,
+            main_feature,
+            _find_vertex_indices(main_feature.geometry(), segment.vertices()),
+            is_reversed=False,
+        )
+    ]
+    for common_part_candidate in common_part_candidates:
+        layer, feature = common_part_candidate
+        indices = _find_vertex_indices(feature.geometry(), segment.vertices())
+        common_parts.append(
+            ReshapeCommonPart(
+                layer,
+                feature,
+                indices,
+                is_reversed=_check_if_vertices_are_reversed(indices),
+            )
+        )
+
+    edges: List[ReshapeEdge] = []
+    for possible_edge_candidate in possible_edge_candidates:
+        layer, feature, component = possible_edge_candidate
+        if start.intersects(component):
+            indices = _find_vertex_indices(feature.geometry(), [segment.startPoint()])
+            edges.append(
+                ReshapeEdge(
+                    layer,
+                    feature,
+                    indices[0],
+                    is_start=True,
+                )
+            )
+        if end.intersects(component):
+            indices = _find_vertex_indices(feature.geometry(), [segment.endPoint()])
+            edges.append(
+                ReshapeEdge(
+                    layer,
+                    feature,
+                    indices[0],
+                    is_start=False,
+                )
+            )
+
+    return segment, common_parts, edges

--- a/test/geometry/test_reshape.py
+++ b/test/geometry/test_reshape.py
@@ -984,3 +984,24 @@ def test_polygon_fully_replaced_by_reshape(
     )
 
     _assert_layer_geoms(layer1, ["POLYGON((2 2, 2 3, 3 3, 3 2, 2 2))"])
+
+
+def test_full_polygon_partially_replaced_by_reshape_auto_closed(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+):
+    layer1, features1 = preset_features_layer_factory(
+        "l1",
+        ["POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))"],
+    )
+
+    make_reshape_edits(
+        [
+            ReshapeCommonPart(layer1, features1[0], [4, 1, 2, 3, 4], False),
+        ],
+        [],
+        QgsLineString([(1, 1), (1, 2), (2, 2), (2, 1)]),
+    )
+
+    _assert_layer_geoms(layer1, ["POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))"])

--- a/test/geometry/test_reshape.py
+++ b/test/geometry/test_reshape.py
@@ -965,10 +965,22 @@ def test_polygon_fully_replaced_by_reshape(
 
     make_reshape_edits(
         [
-            ReshapeCommonPart(layer1, features1[0], [0, 1, 2, 3], False),
+            # input can either be from zero and loop back to zero
+            ReshapeCommonPart(layer1, features1[0], [0, 1, 2, 3, 0], False),
         ],
         [],
         QgsLineString([(1, 1), (1, 2), (2, 2), (2, 1), (1, 1)]),
     )
 
     _assert_layer_geoms(layer1, ["POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))"])
+
+    make_reshape_edits(
+        [
+            # or from last, second and end to last
+            ReshapeCommonPart(layer1, features1[0], [4, 1, 2, 3, 4], False),
+        ],
+        [],
+        QgsLineString([(2, 2), (2, 3), (3, 3), (3, 2), (2, 2)]),
+    )
+
+    _assert_layer_geoms(layer1, ["POLYGON((2 2, 2 3, 3 3, 3 2, 2 2))"])

--- a/test/topology/test_find_related.py
+++ b/test/topology/test_find_related.py
@@ -17,441 +17,708 @@
 #  You should have received a copy of the GNU General Public License
 #  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Callable, List, Optional, Tuple
+from time import perf_counter
+from typing import Callable, List, Tuple
 
 import pytest
-from qgis.core import (
-    QgsFeature,
-    QgsGeometry,
-    QgsLineString,
-    QgsPoint,
-    QgsProject,
-    QgsVectorLayer,
+from qgis.core import QgsFeature, QgsGeometry, QgsProject, QgsVectorLayer
+
+from segment_reshape.topology.find_related import (
+    find_related_features,
+    get_common_geometries,
 )
 
-from segment_reshape.topology import find_related
-from segment_reshape.topology.find_related import find_related_features
+
+def _normalize_wkt(wkt: str) -> str:
+    geom = QgsGeometry.fromWkt(wkt)
+    geom.normalize()
+    return geom.asWkt()
 
 
-@pytest.fixture()
-def main_feature() -> Tuple[QgsFeature, List[QgsFeature]]:
-    main_feature = QgsFeature()
-    main_feature.setGeometry(
-        QgsGeometry.fromWkt(
-            "PolygonZ ((0 0 0, 0 10 0, 5 10 0, 10 10 0, 10 0 0, 0 0 0))"
-        )
-    )
+def _assert_geom_equals_wkt(geom: QgsGeometry, wkt: str) -> None:
+    __tracebackhide__ = True
 
-    return main_feature
+    result = _normalize_wkt(geom.asWkt())
+    target = _normalize_wkt(wkt)
+
+    assert result == target
 
 
-def test_get_common_geometries_with_line_shares_border_should_return_common_segment(
-    main_feature: QgsFeature,
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "expected_segment_wkt"),
+    argvalues=[
+        (
+            "LINESTRING(0 0, 1 1)",
+            (0, 1),
+            "LINESTRING(0 0, 1 1)",
+        ),
+        (
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            (0, 1),
+            "LINESTRING(0 0, 1 1)",
+        ),
+        (
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            (1, 2),
+            "LINESTRING(2 2, 3 3)",
+        ),
+        (
+            "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))",
+            (0, 1),
+            "LINESTRING(0 0, 0 10, 10 10, 10 0, 0 0)",
+        ),
+        (
+            "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))",
+            (5, 6),
+            "LINESTRING(5 5, 5 6, 6 6, 6 5, 5 5)",
+        ),
+        (
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (0, 1),
+            "LINESTRING(0 0, 0 10, 10 10, 10 0, 0 0)",
+        ),
+        (
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (5, 6),
+            "LINESTRING(5 5, 5 6, 6 6, 6 5, 5 5)",
+        ),
+        (
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (10, 11),
+            "LINESTRING(20 20, 20 30, 30 30, 30 20, 20 20)",
+        ),
+        (
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (15, 16),
+            "LINESTRING(25 25, 25 26, 26 26, 26 25, 25 25)",
+        ),
+    ],
+    ids=[
+        "line",
+        "multiline",
+        "multiline-2nd-part",
+        "polygon",
+        "polygon-ring",
+        "multipolygon",
+        "multipolygon-ring",
+        "multipolygon-2nd-part",
+        "multipolygon-2nd-part-ring",
+    ],
+)
+def test_calculate_common_segment_for_single_feature_picks_whole_triggered_component(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    expected_segment_wkt: str,
 ):
-    layer_1 = QgsVectorLayer("layer1")
-    layer_2 = QgsVectorLayer("layer2")
+    layer, (feature,) = preset_features_layer_factory("source", [trigger_wkt])
 
-    line_feature = QgsFeature()
-    # Intersects main feature at: LineStringZ (10 10 0, 5 10 0) -> between vertices 2-3
-    line_feature.setGeometry(
-        QgsGeometry.fromWkt("LineStringZ (15 10 0, 10 10 0, 5 10 0, 0 15 0)")
-    )
-
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(
-        layer_1, main_feature, [(layer_2, line_feature)], (2, 3)
-    )
-
-    assert QgsGeometry(segment).isGeosEqual(
-        QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0)")
-    )
-    assert len(common_segment_results) == 2
-    assert len(segment_end_point_results) == 0
-
-    assert common_segment_results[0].layer == layer_1
-    assert common_segment_results[0].feature == main_feature
-    assert common_segment_results[0].vertex_indices == [2, 3]
-    assert common_segment_results[0].is_reversed is False
-
-    assert common_segment_results[1].layer == layer_2
-    assert common_segment_results[1].feature == line_feature
-    assert common_segment_results[1].vertex_indices == [2, 1]
-    assert common_segment_results[1].is_reversed is True
-
-
-def test_get_common_geometries_with_no_intersecting_features_should_return_polygon_boundary_as_common_segment(
-    main_feature: QgsFeature,
-):
-    layer_1 = QgsVectorLayer("layer1")
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(layer_1, main_feature, [], (2, 3))
-
-    assert QgsGeometry(segment).isGeosEqual(
-        QgsGeometry.fromWkt(
-            "LineStringZ (0 0 0, 0 10 0, 5 10 0, 10 10 0, 10 0 0, 0 0 0)"
-        )
-    )
-    assert len(common_segment_results) == 1
-    assert len(segment_end_point_results) == 0
-
-    assert common_segment_results[0].layer == layer_1
-    assert common_segment_results[0].feature == main_feature
-    assert common_segment_results[0].vertex_indices == [0, 1, 2, 3, 4, 5]
-    assert common_segment_results[0].is_reversed is False
-
-
-def test_get_common_geometries_with_no_intersecting_features_should_return_input_polyline_as_common_segment():
-    layer_1 = QgsVectorLayer("layer1")
-    line_feature = QgsFeature()
-    input_wkt = "LineStringZ (15 10 0, 10 10 0"
-    line_feature.setGeometry(QgsGeometry.fromWkt(input_wkt))
-
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(layer_1, line_feature, [], (0, 1))
-
-    assert QgsGeometry(segment).isGeosEqual(QgsGeometry.fromWkt(input_wkt))
-    assert len(common_segment_results) == 1
-    assert len(segment_end_point_results) == 0
-
-    assert common_segment_results[0].layer == layer_1
-    assert common_segment_results[0].feature == line_feature
-    assert common_segment_results[0].vertex_indices == [0, 1]
-    assert common_segment_results[0].is_reversed is False
-
-
-def test_get_common_geometries_line_shares_one_point_with_main_feature(
-    main_feature: QgsFeature,
-):
-    layer_1 = QgsVectorLayer("layer1")
-    layer_2 = QgsVectorLayer("layer2")
-
-    line_feature = QgsFeature()
-    # Intersects main feature at: PointZ (10 10 0)
-    line_feature.setGeometry(QgsGeometry.fromWkt("LineStringZ (15 10 0, 10 10 0)"))
-
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(
-        layer_1, main_feature, [(layer_2, line_feature)], (0, 1)
-    )
-
-    main_feature_geom_as_polyline = QgsLineString(
-        main_feature.geometry().asPolygon()[0]
-    )
-    assert QgsGeometry(segment).isGeosEqual(QgsGeometry(main_feature_geom_as_polyline))
-
-    assert len(common_segment_results) == 1
-    assert len(segment_end_point_results) == 0
-
-    assert common_segment_results[0].layer == layer_1
-    assert common_segment_results[0].feature == main_feature
-    assert common_segment_results[0].vertex_indices == [0, 1, 2, 3, 4, 5]
-    assert common_segment_results[0].is_reversed is False
-
-
-def test_get_common_geometries_with_multiple_results_should_return_common_segments_and_edgess(
-    main_feature: QgsFeature,
-):
-    layer_1 = QgsVectorLayer("layer1")
-    layer_2 = QgsVectorLayer("layer2")
-
-    line_feature_1 = QgsFeature()
-    # Intersects main feature at: LineStringZ (10 10 0, 5 10 0) -> between vertices 2-3
-    line_feature_1.setGeometry(
-        QgsGeometry.fromWkt("LineStringZ (15 10 0, 10 10 0, 5 10 0, 0 15 0)")
-    )
-
-    line_feature_2 = QgsFeature()
-    # Intersects main feature at: PointZ (10 10 0) -> vertex 2
-    line_feature_2.setGeometry(QgsGeometry.fromWkt("LineStringZ (15 10 0, 10 10 0)"))
-
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(
-        layer_1,
-        main_feature,
-        [(layer_2, line_feature_1), (layer_2, line_feature_2)],
-        (2, 3),
-    )
-
-    assert QgsGeometry(segment).isGeosEqual(
-        QgsGeometry.fromWkt("LineStringZ (5 10 0, 10 10 0)")
-    )
-    assert len(common_segment_results) == 2
-
-    assert common_segment_results[0].layer == layer_1
-    assert common_segment_results[0].feature == main_feature
-    assert common_segment_results[0].vertex_indices == [2, 3]
-    assert common_segment_results[0].is_reversed is False
-
-    assert common_segment_results[1].layer == layer_2
-    assert common_segment_results[1].feature == line_feature_1
-    assert common_segment_results[1].vertex_indices == [2, 1]
-    assert common_segment_results[1].is_reversed is True
-
-    assert len(segment_end_point_results) == 1
-
-    assert segment_end_point_results[0].layer == layer_2
-    assert segment_end_point_results[0].feature == line_feature_2
-    assert segment_end_point_results[0].vertex_index == 1
-    assert segment_end_point_results[0].is_start is False
-
-
-@pytest.mark.timeout(3)
-def test_get_common_geometries_with_large_features():
-    layer_1 = QgsVectorLayer("layer1")
-    feature = QgsFeature()
-
-    polygon_wkt = "Polygon (("
-    polygon_wkt += ", ".join([f"{x} 0" for x in range(1001)]) + ", "
-    polygon_wkt += ", ".join([f"1000 {y}" for y in range(1001)]) + ", "
-    polygon_wkt += ", ".join([f"{x} 1000" for x in range(1000, -1, -1)]) + ", "
-    polygon_wkt += ", ".join([f"0 {y}" for y in range(1000, -1, -1)])
-    polygon_wkt += "))"
-
-    feature.setGeometry(QgsGeometry.fromWkt(polygon_wkt))
-    assert not feature.geometry().isEmpty()
-    assert feature.geometry().isGeosValid()
-
-    intersecting_feature = QgsFeature()
-    linestring_wkt = (
-        "LineString (" + ", ".join([f"{x} 0" for x in range(-500, 1500)]) + ")"
-    )
-    intersecting_feature.setGeometry(QgsGeometry.fromWkt(linestring_wkt))
-    assert not intersecting_feature.geometry().isEmpty()
-    assert intersecting_feature.geometry().isGeosValid()
-
-    (
-        segment,
-        common_segment_results,
-        segment_end_point_results,
-    ) = find_related.get_common_geometries(
-        layer_1,
+    (segment, _, _) = get_common_geometries(
+        layer,
         feature,
-        [(layer_1, intersecting_feature)],
-        (0, 1),
+        [],
+        trigger_indices,
     )
 
     assert segment is not None
-    assert len(common_segment_results) == 2
-    assert len(segment_end_point_results) == 0
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
 
 
 @pytest.mark.parametrize(
-    ("geoms", "expected_result"),
-    [
+    argnames=("trigger_wkt", "trigger_indices", "expected_result_indices"),
+    argvalues=[
         (
-            [QgsGeometry.fromWkt("LineStringZ (15 10 0, 10 10 0, 5 10 0, 0 15 0)")],
-            QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0)"),
+            "LINESTRING(0 0, 1 1)",
+            (0, 1),
+            [0, 1],
         ),
         (
-            [QgsGeometry.fromWkt("LineStringZ (15 10 2, 10 10 2, 5 10 2, 0 15 2)")],
-            QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0)"),
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            (0, 1),
+            [0, 1],
         ),
         (
-            [QgsGeometry.fromWkt("LineStringZ (10 10 0, 8.8 10 0, 5 10 0)")],
-            None,
+            "MULTILINESTRING((0 0, 1 1), (2 2, 3 3))",
+            (2, 3),
+            [2, 3],
         ),
         (
-            [QgsGeometry.fromWkt("LineStringZ (8.8 10 0, 5.2 10 0)")],
-            None,
+            "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))",
+            (0, 1),
+            [4, 1, 2, 3, 4],
         ),
         (
-            [QgsGeometry.fromWkt("LineStringZ (10 10 0, 3 10 0)")],
-            None,
+            "POLYGON((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5))",
+            (5, 6),
+            [9, 6, 7, 8, 9],
         ),
         (
-            # Intersects main feature at: LineStringZ (10 10 0, 5 10 0, 3 10 0), PointZ (10 6 0)
-            [
-                QgsGeometry.fromWkt(
-                    "LineStringZ (10 6 0, 15 6 0, 15 10 0, 10 10 0, 5 10 0, 3 10 0, 0 15 0)"
-                )
-            ],
-            QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0)"),
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (0, 1),
+            [4, 1, 2, 3, 4],
         ),
         (
-            [
-                QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0, 5 15 0)"),
-                QgsGeometry.fromWkt(
-                    "LineStringZ (10 6 0, 15 6 0, 15 10 0, 10 10 0, 5 10 0, 3 10 0, 0 15 0)"
-                ),
-            ],
-            QgsGeometry.fromWkt("LineStringZ (10 10 0, 5 10 0)"),
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (5, 6),
+            [9, 6, 7, 8, 9],
         ),
         (
-            [QgsGeometry.fromWkt("PointZ (10 10 0)")],
-            None,
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (10, 11),
+            [14, 11, 12, 13, 14],
         ),
         (
-            [QgsGeometry.fromWkt("PointZ (7 10 0)")],
-            None,
-        ),
-        (
-            [QgsGeometry.fromWkt("PolygonZ ((5 5 0, 5 15 0, 15 15 0, 15 5 0, 5 5 0))")],
-            None,
-        ),
-        (
-            [
-                # Intersects main feature at: LineStringZ (10 10 0, 5 10 0), LineStringZ (10 6 0, 20 2 0)
-                QgsGeometry.fromWkt(
-                    "PolygonZ ((5 18 0, 5 10 0, 10 10 0, 10 13 0, 11 13 0, 11 6 0, 10 6 0, 10 2 0, 13 2 0, 13 18 0, 5 18 0))"
-                ),
-                QgsGeometry.fromWkt(
-                    "LineStringZ (10 6 0, 15 6 0, 15 10 0, 10 10 0, 3 10 0, 0 15 0)"
-                ),
-            ],
-            QgsGeometry.fromWkt("LineStringZ (5 10 0, 10 10 0)"),
-        ),
-        (
-            [],
-            None,
+            "MULTIPOLYGON("
+            "((0 0, 0 10, 10 10, 10 0, 0 0), (5 5, 5 6, 6 6, 6 5, 5 5)),"
+            "((20 20, 20 30, 30 30, 30 20, 20 20), (25 25, 25 26, 26 26, 26 25, 25 25))"
+            ")",
+            (15, 16),
+            [19, 16, 17, 18, 19],
         ),
     ],
     ids=[
-        "line shares polygon border",
-        "line shares polygon border in 2D but not 3D",
-        "line shares polygon border but have extra vertices",
-        "line shares polygon border but does not match polygon vertices",
-        "line shares polygon border but does not have all common vertices",
-        "line multi-intersects polygon border",
-        "2 lines multi-intersect polygon border",
-        "point on polygon border but not on trigger point",
-        "point on polygon border on trigger point",
-        "overlapping polygon with no common vertices",
-        "adjacent polygon plus intersecting line, multiple shared segments",
-        "empty input list",
+        "line",
+        "multiline",
+        "multiline-2nd-part",
+        "polygon",
+        "polygon-ring",
+        "multipolygon",
+        "multipolygon-ring",
+        "multipolygon-2nd-part",
+        "multipolygon-2nd-part-ring",
     ],
 )
-def test_calculate_common_segment(
-    geoms: List[QgsGeometry], expected_result: QgsGeometry
+def test_calculate_common_segment_for_single_feature_results_in_single_reshape_part_and_no_edges(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    expected_result_indices: List[int],
 ):
-    assert len([geom for geom in geoms if geom.isEmpty()]) == 0, "Error in input wkt"
+    layer, (feature,) = preset_features_layer_factory("source", [trigger_wkt])
 
-    main_geom = QgsGeometry.fromWkt(
-        "PolygonZ ((0 0 0, 0 10 0, 3 10 0, 5 10 0, 10 10 0, 10 6 0, 10 2 0, 10 0 0, 0 0 0))"
+    (_, common_parts, edges) = get_common_geometries(
+        layer,
+        feature,
+        [],
+        trigger_indices,
     )
 
-    resulting_line = find_related._calculate_common_segment(
-        main_geom,
-        geoms,
-        QgsGeometry(QgsPoint(5, 10, 0)),
-        QgsGeometry(QgsPoint(10, 10, 0)),
+    assert len(edges) == 0
+    assert len(common_parts) == 1
+    common_part = common_parts[0]
+
+    assert common_part.layer == layer
+    assert common_part.feature == feature
+    assert common_part.vertex_indices == expected_result_indices
+    assert not common_part.is_reversed
+
+
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_part_details"),
+    argvalues=[
+        (
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(-1 -1, 0 0, 1 1, 2 2, 3 3)"],
+            [([0, 1, 2], False), ([1, 2, 3], False)],
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(3 3, 2 2, 1 1, 0 0, -1 -1)"],
+            [([0, 1, 2], False), ([3, 2, 1], True)],
+        ),
+    ],
+    ids=[
+        "other-fully-common-with-trigger",
+        "other-fully-common-with-trigger-reversed",
+    ],
+)
+def test_calculate_common_segment_for_multiple_lines_results_in_multiple_reshape_parts(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_part_details: List[Tuple[List[int], bool]],
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
     )
 
-    if resulting_line is None:
-        assert expected_result is None
-    else:
-        assert (
-            expected_result is not None
-        ), f"Did not expect to find common segment, got {resulting_line.asWkt()}"
-        assert QgsGeometry(resulting_line).isGeosEqual(expected_result)
+    (_, common_parts, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert len(common_parts) == len(expected_part_details)
+
+    for common_part, (expected_indices, expected_reversed) in zip(
+        common_parts, expected_part_details
+    ):
+        assert common_part.vertex_indices == expected_indices
+        assert common_part.is_reversed == expected_reversed
 
 
 @pytest.mark.parametrize(
-    ("geom", "segment", "expected_result"),
-    [
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_edge_details"),
+    argvalues=[
         (
-            QgsGeometry.fromWkt("PolygonZ ((0 0 0, 2 0 0, 2 2 0, 0 2 0, 0 0 0))"),
-            QgsGeometry.fromWkt("LineStringZ (0 0 0, 2 0 0, 2 2 0, 0 2 0, 0 0 0)"),
-            [0, 1, 2, 3, 4],
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(-1 -1, 0 0)", "LINESTRING(2 2, 3 3)"],
+            [(1, True), (0, False)],
         ),
         (
-            QgsGeometry.fromWkt("PolygonZ ((0 0 0, 2 0 0, 2 2 0, 0 2 0, 0 0 0))"),
-            QgsGeometry.fromWkt("LineStringZ (0 0 0, 0 2 0, 2 2 0, 2 0 0, 0 0 0)"),
-            [4, 3, 2, 1, 0],
+            "LINESTRING(-1 0, 0 0, 1 1, 2 2, 3 2)",
+            (1, 2),
+            ["LINESTRING(-1 -1, 0 0)", "LINESTRING(2 2, 3 3)"],
+            [(1, True), (0, False)],
         ),
         (
-            QgsGeometry.fromWkt("PolygonZ ((0 0 0, 2 0 0, 2 2 0, 0 2 0, 0 0 0))"),
-            QgsGeometry.fromWkt("LineStringZ (2 2 0, 0 2 0, 0 0 0, 0 0 0, 2 0 0)"),
-            [2, 3, 4, 0, 1],
-        ),
-        (
-            QgsGeometry.fromWkt("PolygonZ ((0 0 0, 2 0 0, 2 2 0, 0 2 0, 0 0 0))"),
-            QgsGeometry.fromWkt("LineStringZ (0 2 0, 2 2 0, 2 0 0, 0 0 0, 0 0 0)"),
-            [3, 2, 1, 0, 4],
-        ),
-        (
-            QgsGeometry.fromWkt("LineStringZ (0 0 0, 2 0 0, 4 0 0, 6 0 0)"),
-            QgsGeometry.fromWkt("LineStringZ (2 0 0, 4 0 0)"),
-            [1, 2],
-        ),
-        (
-            QgsGeometry.fromWkt("LineStringZ (0 0 0, 2 0 0, 4 0 0, 6 0 0)"),
-            QgsGeometry.fromWkt("LineStringZ (2 0 0, 5 0 0)"),
-            None,
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(-1 -1, 0 0, 2 0, 2 2, 3 3)"],
+            [(1, True), (3, False)],
         ),
     ],
     ids=[
-        "polygon boundary as segment",
-        "polygon boundary as segment, reversed",
-        "polygon boundary as segment, start from middle",
-        "polygon boundary as segment, start from middle, reversed",
-        "line segment",
-        "line when segment vertex does not match",
+        "two-lines-at-trigger-feature-ends",
+        "two-lines-breaking-trigger-feature",
+        "same-feature-as-multiple-edges",
     ],
 )
-def test_get_vertex_indices_of_segment(
-    geom: QgsGeometry, segment: QgsGeometry, expected_result: Optional[List[int]]
+def test_calculate_common_segment_for_multiple_lines_results_in_multiple_edges(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_edge_details: List[Tuple[int, bool]],
 ):
-    assert not geom.isEmpty()
-    assert not segment.isEmpty()
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
 
-    if expected_result is None:
-        with pytest.raises(ValueError):
-            find_related._get_vertex_indices_of_segment(geom, segment)
-    else:
-        assert (
-            find_related._get_vertex_indices_of_segment(geom, segment)
-            == expected_result
-        )
+    (_, _, edges) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert len(edges) == len(expected_edge_details)
+
+    for edge, (expected_index, expected_start) in zip(edges, expected_edge_details):
+        assert edge.vertex_index == expected_index
+        assert edge.is_start == expected_start
 
 
 @pytest.mark.parametrize(
-    ("vertex_indices", "expected_result"),
-    [
-        (
-            [0, 1, 2, 3],
-            False,
-        ),
-        (
-            [3, 0, 1, 2],
-            False,
-        ),
-        (
-            [1, 0, 3, 2],
-            True,
-        ),
-        (
-            [3, 2, 1, 0],
-            True,
-        ),
+    argnames=("count", "allowed_duration_ms"),
+    argvalues=[
+        (1000, 100),
+        (2000, 200),
+        (10000, 500),
     ],
     ids=[
-        "from start point, not reversed",
-        "from end point, not reversed",
-        "from second point, is reversed",
-        "from end point, is reversed",
+        "1000x4-in-100-ms",
+        "2000x4-in-200-ms",
+        "10000x4-in-500-ms",
     ],
 )
-def test_check_if_vertices_are_reversed(
-    vertex_indices: List[int], expected_result: bool
+def test_calculate_common_segment_for_huge_polygon_coordinate_count_is_fast_enough(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    count: int,
+    allowed_duration_ms: int,
 ):
+    polygon_wkt = "Polygon (("
+    polygon_wkt += ", ".join([f"{x} 0" for x in range(count + 1)]) + ", "
+    polygon_wkt += ", ".join([f"{count} {y}" for y in range(count + 1)]) + ", "
+    polygon_wkt += ", ".join([f"{x} {count}" for x in range(count, -1, -1)]) + ", "
+    polygon_wkt += ", ".join([f"0 {y}" for y in range(count, -1, -1)])
+    polygon_wkt += "))"
+
+    other_wkt = (
+        "LINESTRING(" + ", ".join([f"{x} 0" for x in range(-500, count + 500)]) + ")"
+    )
+
+    layer, (feature,) = preset_features_layer_factory("source", [polygon_wkt])
+    other_layer, (other_feature,) = preset_features_layer_factory("other", [other_wkt])
+
+    start = perf_counter()
+    get_common_geometries(
+        layer,
+        feature,
+        [(other_layer, other_feature)],
+        (count // 2, count // 2 - 1),
+    )
+    end = perf_counter()
+
     assert (
-        find_related._check_if_vertices_are_reversed(vertex_indices) is expected_result
+        end - start
+    ) / 1000 < allowed_duration_ms, "common geometry code was not fast enough"
+
+
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (
+            "LineStringZ (15 10 0, 10 10 0, 5 10 0, 0 15 0)",
+            (1, 2),
+            ["LineStringZ (10 10 0, 5 10 0)"],
+            "LineStringZ (10 10 0, 5 10 0)",
+        ),
+        (
+            "LineStringZ (15 10 2, 10 10 2, 5 10 2, 0 15 2)",
+            (1, 2),
+            ["LineStringZ (10 10 0, 5 10 0)"],
+            # investigate why this way (0 and 2, not only 0 or only 2)
+            # new line will be digitized without zs anyway
+            "LineStringZ (10 10 0, 5 10 2)",
+        ),
+    ],
+    ids=[
+        "same-z-is-common-segment",
+        "different-z-is-common-segment",
+    ],
+)
+def test_calculate_common_segment_does_not_consider_z_dimension(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
     )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
+
+
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)",
+            (2, 3),
+            ["LINESTRING(4 4, 5 5)"],
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4)",
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(0 0, 1 1)", "LINESTRING(6 6, 7 7)"],
+            "LINESTRING(1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(1 0, 1 1, 1 2)", "LINESTRING(6 5, 6 6, 6 7)"],
+            "LINESTRING(1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(0 1, 1 1, 1 0)", "LINESTRING(5 6, 6 6, 6 5)"],
+            "LINESTRING(1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(0 0, 1 1, 1 2, 5 6, 6 6, 7 7)"],
+            "LINESTRING(1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        ),
+        (
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(1 0, 1 1, 1 2, 5 6, 6 6, 7 6)"],
+            "LINESTRING(1 1, 2 2, 3 3, 4 4, 5 5, 6 6)",
+        ),
+    ],
+    ids=[
+        "self-outside-shared-expands-until-shared-and-end",
+        "self-between-shared-expands-until-shared",
+        "self-between-touching-expands-until-breaks",
+        "self-between-intersect-expands-until-breaks",
+        "self-between-other-partly-disjoint-expands-until-rejoin",
+        "self-between-other-fully-disjoint-crosses-at-vertex-expands-until-breaks",
+    ],
+)
+def test_calculate_common_segment_line_trigger_expanded(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
+
+
+def test_calculate_common_segment_line_broken_by_points_as_edges(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+):
+    layer, (feature,) = preset_features_layer_factory(
+        "source", ["LINESTRING(-1 -1, 0 0, 1 1, 2 2, 3 3, 4 4)"]
+    )
+    other_layer, (point_1, point_2) = preset_features_layer_factory(
+        "other", ["POINT(0 0)", "POINT(3 3)"]
+    )
+
+    (segment, common_parts, edges) = get_common_geometries(
+        layer,
+        feature,
+        [(other_layer, point_1), (other_layer, point_2)],
+        (2, 3),
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, "LINESTRING(0 0, 1 1, 2 2, 3 3)")
+
+    assert len(common_parts) == 1  # source feature only
+    assert len(edges) == 2  # points as edges
+
+    edge_1, edge_2 = edges
+
+    _assert_geom_equals_wkt(edge_1.feature.geometry(), "POINT(0 0)")
+    assert edge_1.is_start
+    _assert_geom_equals_wkt(edge_2.feature.geometry(), "POINT(3 3)")
+    assert not edge_2.is_start
+
+
+@pytest.mark.xfail(reason="TODO: cross or touch at non-vertex should not break segment")
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (  # see TODO for get_common_geometries difference, cross at non-vertex
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(1 0, 0 1)"],
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+        ),
+        (  # see TODO for get_common_geometries difference, touch at non-vertex
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+            (3, 4),
+            ["LINESTRING(1 0, 1.5 1.5, 2 0, 5 0, 5.5 5.5, 6 0)"],
+            "LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5, 6 6, 7 7)",
+        ),
+    ],
+    ids=[
+        "self-between-other-fully-disjoint-cross-not-at-vertex-expands-fully",
+        "self-between-other-fully-disjoint-touch-not-at-vertex-expands-fully",
+    ],
+)
+def test_calculate_common_segment_line_having_related_feature_not_at_vertex_trigger_expanded(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
+
+
+@pytest.mark.xfail(reason="TODO: partial linear intersection should not break segment")
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (  # see TODO for get_common_geometries difference, partial linear intersection
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(1.5 1.5, 2 2, 3 3)"],
+            "LINESTRING(0 0, 1 1, 2 2)",
+        ),
+    ],
+    ids=[
+        "partial-linear-intersection-only-breaks-at-shared-vertex",
+    ],
+)
+def test_calculate_common_segment_line_having_related_feature_linear_intersect_trigger_expanded(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
+
+
+@pytest.mark.xfail(reason="TODO: broken continuous ring should be rejoined at boundary")
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (  # see TODO for get_common_geometries mergeLines
+            "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))",
+            (0, 1),
+            ["POLYGON((1 0, 1 1, 2 1, 2 0, 1 0))"],  # 1 0, 1 1 shared, removed
+            "LINESTRING(1 0, 0 0, 0 1, 1 1)",
+        ),
+        (  # see TODO for get_common_geometries mergeLines
+            "POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))",
+            (0, 1),
+            ["POLYGON((2 0, 1 1, 2 1, 2 0))"],  # 1 1 touched, split
+            "LINESTRING(1 1, 1 0, 0 0, 0 1, 1 1)",
+        ),
+    ],
+    ids=[
+        "shared-intersection-removed",
+        "touch-location-split",
+    ],
+)
+def test_calculate_common_segment_polygon_ring_boundary_crossed(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
+
+
+@pytest.mark.xfail(reason="TODO: trigger should be contained as same sequence")
+@pytest.mark.parametrize(
+    argnames=("trigger_wkt", "trigger_indices", "other_wkts", "expected_segment_wkt"),
+    argvalues=[
+        (  # see TODO for get_common_geometries intersection, partial linear intersection
+            "LINESTRING(0 0, 1 1, 2 2)",
+            (0, 1),
+            ["LINESTRING(0 0, 2 2)"],
+            "LINESTRING(0 0, 2 2)",
+        ),
+        (  # see TODO for get_common_geometries intersection, partial linear intersection
+            "LINESTRING(0 0, 1 1)",
+            (0, 1),
+            ["LINESTRING(0 0, 0.5 0.5, 1 1)"],
+            "LINESTRING(0 0, 1 1)",
+        ),
+    ],
+    ids=[
+        "component-fully-contains-trigger-in-one-larger-segment-should-not-break",
+        "component-fully-contains-trigger-in-multiple-segments-should-not-break",
+    ],
+)
+def test_calculate_common_segment_line_having_related_feature_contains_trigger_as_difference_sequence(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    trigger_wkt: str,
+    trigger_indices: Tuple[int, int],
+    other_wkts: List[str],
+    expected_segment_wkt: str,
+):
+    layer, (feature, *other_features) = preset_features_layer_factory(
+        "source", [trigger_wkt] + other_wkts
+    )
+
+    (segment, _, _) = get_common_geometries(
+        layer,
+        feature,
+        [(layer, f) for f in other_features],
+        trigger_indices,
+    )
+
+    assert segment is not None
+    _assert_geom_equals_wkt(segment, expected_segment_wkt)
 
 
 @pytest.mark.usefixtures("qgis_new_project")

--- a/test/topology/test_find_related.py
+++ b/test/topology/test_find_related.py
@@ -398,15 +398,13 @@ def test_calculate_common_segment_for_huge_polygon_coordinate_count_is_fast_enou
             "LineStringZ (15 10 0, 10 10 0, 5 10 0, 0 15 0)",
             (1, 2),
             ["LineStringZ (10 10 0, 5 10 0)"],
-            "LineStringZ (10 10 0, 5 10 0)",
+            "LineString (10 10, 5 10)",
         ),
         (
             "LineStringZ (15 10 2, 10 10 2, 5 10 2, 0 15 2)",
             (1, 2),
             ["LineStringZ (10 10 0, 5 10 0)"],
-            # investigate why this way (0 and 2, not only 0 or only 2)
-            # new line will be digitized without zs anyway
-            "LineStringZ (10 10 0, 5 10 2)",
+            "LineString (10 10, 5 10)",
         ),
     ],
     ids=[
@@ -435,6 +433,13 @@ def test_calculate_common_segment_does_not_consider_z_dimension(
     )
 
     assert segment is not None
+
+    # only test for 2d equality, since for different z case windows
+    # returns (10 10 0, 5 10 2) and linux returns (10 10 1, 5 10 1)
+    # investigate and possibly decide what should happen with z coords,
+    # maybe always use the source geometry z's?
+    segment.dropZValue()
+
     _assert_geom_equals_wkt(segment, expected_segment_wkt)
 
 

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -5,6 +5,7 @@ geom
 geoms
 i18n
 iface
+num
 polyline
 pos
 qgis


### PR DESCRIPTION
Support more complex cases for calculating the common segment, and fix case where a shared polygon was only reshaped as an edge, not as an shared segment.