### PR TITLE
Enable key commands in vertex editing phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+- Feat: Add support for key commands (backspace and esc)
 
 ## [0.0.3] - 2022-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+
 - Feat: Add support for key commands (backspace and esc)
 
 ## [0.0.3] - 2022-11-17

--- a/src/segment_reshape/map_tool/segment_reshape_tool.py
+++ b/src/segment_reshape/map_tool/segment_reshape_tool.py
@@ -78,7 +78,6 @@ class SegmentReshapeTool(QgsMapToolEdit):
         self.temporary_new_segment_rubber_band.reset()
 
         self.find_segment_results = (None, [], [])
-
         self.snap_indicator.setVisible(False)
 
     def _change_to_reshape_mode(self) -> None:
@@ -207,18 +206,15 @@ class SegmentReshapeTool(QgsMapToolEdit):
         self, location: QgsPointXY
     ) -> Tuple[Optional[QgsLineString], Optional[QgsVectorLayer]]:
         LOGGER.info("Calculating common segment")
-
         active_layer = iface.activeLayer()
         if active_layer is None:
             MsgBar.warning(tr("No active layer found"), tr("Activate a layer first"))
             return None, None
-
         identify_results = self._identify_tool.identify(
             geometry=QgsGeometry.fromPointXY(location),
             mode=QgsMapToolIdentify.ActiveLayer,
             layerType=QgsMapToolIdentify.VectorLayer,
         )
-
         try:
             feature = [result.mFeature for result in identify_results][0]
         except IndexError:
@@ -226,15 +222,12 @@ class SegmentReshapeTool(QgsMapToolEdit):
                 tr("Did not find any active layer feature at mouse location")
             )
             return None, None
-
         (
             *_,
             next_vertex_index,
             _,
         ) = feature.geometry().closestSegmentWithContext(location)
-
         self.find_segment_results = find_related.find_segment_to_reshape(
             active_layer, feature, (next_vertex_index, next_vertex_index - 1)
         )
-
         return self.find_segment_results[0], active_layer

--- a/src/segment_reshape/map_tool/segment_reshape_tool.py
+++ b/src/segment_reshape/map_tool/segment_reshape_tool.py
@@ -54,7 +54,7 @@ class SegmentReshapeTool(QgsMapToolEdit):
         self.new_segment_rubber_band = QgsRubberBand(canvas)
         self.new_segment_rubber_band.setStrokeColor(QColor(200, 50, 50))
         self.new_segment_rubber_band.setWidth(3)
-        self.added_points = [QgsPointXY]
+        self.added_points = []  # type: ignore
 
         self.temporary_new_segment_rubber_band = QgsRubberBand(canvas)
         self.temporary_new_segment_rubber_band.setStrokeColor(QColor(200, 50, 50))
@@ -74,7 +74,7 @@ class SegmentReshapeTool(QgsMapToolEdit):
 
         self.old_segment_rubber_band.reset()
         self.new_segment_rubber_band.reset()
-        self.added_points = [QgsPointXY]
+        self.added_points = []
         self.temporary_new_segment_rubber_band.reset()
 
         self.find_segment_results = (None, [], [])
@@ -170,7 +170,7 @@ class SegmentReshapeTool(QgsMapToolEdit):
         if self.reshape_mode is True:
             if key == Qt.Key_Escape or len(self.added_points) == 0:
                 self.new_segment_rubber_band.reset()
-                self.added_points = [QgsPointXY]
+                self.added_points = []
                 self.temporary_new_segment_rubber_band.reset()
                 self._change_to_pick_location_mode()
                 return

--- a/test/map_tool/test_segment_reshape_tool.py
+++ b/test/map_tool/test_segment_reshape_tool.py
@@ -82,6 +82,44 @@ def test_change_to_pick_location_mode_resets_rubberbands(map_tool: SegmentReshap
     assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
+def test_pressing_esc_in_reshape_mode_aborts_reshape(map_tool: SegmentReshapeTool):
+    map_tool.old_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.temporary_new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Escape)
+
+    assert map_tool.pick_location_mode is True
+    assert map_tool.reshape_mode is False
+    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
+def test_pressing_esc_in_reshape_mode_with_empty_rubberbands_aborts_reshape(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.old_segment_rubber_band.reset()
+    map_tool.new_segment_rubber_band.reset()
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Escape)
+
+    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
 def test_change_to_change_to_reshape_mode_toggles_pick_mode_off(
     map_tool: SegmentReshapeTool,
 ):
@@ -177,6 +215,83 @@ def test_left_mouse_click_in_reshape_mode_adds_points_to_rubberbands(
     assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
     m_make_reshape_edits.assert_not_called()
+
+
+def test_pressing_backspace_in_reshape_mode_removes_point_from_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.old_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.temporary_new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.pick_location_mode is False
+    assert map_tool.reshape_mode is True
+    assert (
+        map_tool.new_segment_rubber_band.asGeometry().asWkt()
+        == "LineString (0 0, 1 1, 2 2, 3 3, 4 4)"
+    )
+    assert not map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
+def test_pressing_backspace_twice_in_reshape_mode_removes_points_from_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert (
+        map_tool.new_segment_rubber_band.asGeometry().asWkt()
+        == "LineString (0 0, 1 1, 2 2, 3 3)"
+    )
+
+
+def test_pressing_backspace_in_reshape_mode_with_only_start_point_in_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.new_segment_rubber_band.asGeometry().asWkt() == "LineString (0 0)"
+
+
+def test_pressing_backspace_in_reshape_mode_with_empty_rubberbands_aborts_reshape(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.old_segment_rubber_band.reset()
+    map_tool.new_segment_rubber_band.reset()
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.pick_location_mode is True
+    assert map_tool.reshape_mode is False
+    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
 def test_right_mouse_click_in_reshape_mode_changes_only_to_pick_mode_if_edited_geometry_is_empty(

--- a/test/map_tool/test_segment_reshape_tool.py
+++ b/test/map_tool/test_segment_reshape_tool.py
@@ -262,24 +262,23 @@ def test_pressing_backspace_twice_in_reshape_mode_removes_points_from_rubberband
     )
 
 
-def test_pressing_backspace_in_reshape_mode_with_only_start_point_in_rubberband(
+def test_pressing_backspace_in_reshape_mode_with_only_one_point_in_rubberband(
     map_tool: SegmentReshapeTool,
 ):
-    map_tool.new_segment_rubber_band.setToGeometry(
-        QgsGeometry.fromWkt("LINESTRING(0 0)")
-    )
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.new_segment_rubber_band.setToGeometry(QgsGeometry.fromWkt("POINT(1 1)"))
     map_tool.pick_location_mode = False
     map_tool.reshape_mode = True
 
     map_tool._handle_key_event(Qt.Key_Backspace)
 
-    assert map_tool.new_segment_rubber_band.asGeometry().asWkt() == "LineString (0 0)"
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
-def test_pressing_backspace_in_reshape_mode_with_empty_rubberbands_aborts_reshape(
+def test_pressing_backspace_in_reshape_mode_with_no_points_in_rubberband(
     map_tool: SegmentReshapeTool,
 ):
-    map_tool.old_segment_rubber_band.reset()
     map_tool.new_segment_rubber_band.reset()
     map_tool.temporary_new_segment_rubber_band.reset()
     map_tool.pick_location_mode = False
@@ -287,11 +286,8 @@ def test_pressing_backspace_in_reshape_mode_with_empty_rubberbands_aborts_reshap
 
     map_tool._handle_key_event(Qt.Key_Backspace)
 
-    assert map_tool.pick_location_mode is True
-    assert map_tool.reshape_mode is False
-    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
     assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
-    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
 def test_right_mouse_click_in_reshape_mode_changes_only_to_pick_mode_if_edited_geometry_is_empty(


### PR DESCRIPTION
Lisätty näppäinkomennot:

backspace / delete -> poistetaan edellinen muokattavaan segmenttiin digitoitu verteksi
ESC -> poistetaan koko muokattavana ollut segmentti