### PR TITLE
Feat: Add support for key commands (backspace and esc) in vertex editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Feat: Add support for key commands (backspace and esc) in vertex editing
+
 ## [0.0.3] - 2022-11-17
 
 - Fix: Fix missing toolbar icon by including resource files in setuptools build

--- a/test/map_tool/test_segment_reshape_tool.py
+++ b/test/map_tool/test_segment_reshape_tool.py
@@ -82,6 +82,44 @@ def test_change_to_pick_location_mode_resets_rubberbands(map_tool: SegmentReshap
     assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
+def test_pressing_esc_in_reshape_mode_aborts_reshape(map_tool: SegmentReshapeTool):
+    map_tool.old_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.temporary_new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Escape)
+
+    assert map_tool.pick_location_mode is True
+    assert map_tool.reshape_mode is False
+    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
+def test_pressing_esc_in_reshape_mode_with_empty_rubberbands_aborts_reshape(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.old_segment_rubber_band.reset()
+    map_tool.new_segment_rubber_band.reset()
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Escape)
+
+    assert map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
 def test_change_to_change_to_reshape_mode_toggles_pick_mode_off(
     map_tool: SegmentReshapeTool,
 ):
@@ -177,6 +215,79 @@ def test_left_mouse_click_in_reshape_mode_adds_points_to_rubberbands(
     assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
     m_make_reshape_edits.assert_not_called()
+
+
+def test_pressing_backspace_in_reshape_mode_removes_point_from_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.old_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.temporary_new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.pick_location_mode is False
+    assert map_tool.reshape_mode is True
+    assert (
+        map_tool.new_segment_rubber_band.asGeometry().asWkt()
+        == "LineString (0 0, 1 1, 2 2, 3 3, 4 4)"
+    )
+    assert not map_tool.old_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
+def test_pressing_backspace_twice_in_reshape_mode_removes_points_from_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.new_segment_rubber_band.setToGeometry(
+        QgsGeometry.fromWkt("LINESTRING(0 0, 1 1, 2 2, 3 3, 4 4, 5 5)")
+    )
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert (
+        map_tool.new_segment_rubber_band.asGeometry().asWkt()
+        == "LineString (0 0, 1 1, 2 2, 3 3)"
+    )
+
+
+def test_pressing_backspace_in_reshape_mode_with_only_one_point_in_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.new_segment_rubber_band.setToGeometry(QgsGeometry.fromWkt("POINT(0 0)"))
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
+
+
+def test_pressing_backspace_in_reshape_mode_with_no_points_in_rubberband(
+    map_tool: SegmentReshapeTool,
+):
+    map_tool.new_segment_rubber_band.reset()
+    map_tool.temporary_new_segment_rubber_band.reset()
+    map_tool.pick_location_mode = False
+    map_tool.reshape_mode = True
+
+    map_tool._handle_key_event(Qt.Key_Backspace)
+
+    assert map_tool.new_segment_rubber_band.asGeometry().isEmpty()
+    assert not map_tool.temporary_new_segment_rubber_band.asGeometry().isEmpty()
 
 
 def test_right_mouse_click_in_reshape_mode_changes_only_to_pick_mode_if_edited_geometry_is_empty(


### PR DESCRIPTION
Enabled two key commands in reshape mode for more user friendly vertex editing:

Backspace / Delete -> remove previous edited vertex of the segment the user is working on
ESC -> remove the whole segment the user was working on