### PR TITLE
Performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Feature: Change the mouse cursor to the wait cursor when finding common segment os editing is in progress
+- Performance improvments. Finding a common segment should now be a magnitude faster with large geometries.
+
 ## [0.1.3] - 2023-03-23
 
 - Feature: Digitizing the new geometry for a segment behaves now as the native QGIS digitizing tools. It supports etc. snapping, tracing and advanced cad tools.

--- a/src/segment_reshape/topology/find_related.py
+++ b/src/segment_reshape/topology/find_related.py
@@ -17,17 +17,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import (
-    FrozenSet,
-    Iterable,
-    Iterator,
-    List,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    cast,
-)
+from typing import FrozenSet, Iterable, Iterator, List, NamedTuple, Optional, Set, Tuple
 
 from qgis.core import (
     QgsAbstractGeometry,
@@ -347,9 +337,7 @@ def get_common_geometries(
 
 
 def _as_line_segments(geometry: QgsGeometry) -> Set[Segment]:
-    vertices = [
-        (point.x(), point.y()) for point in cast(QgsLineString, geometry.asPolyline())
-    ]
+    vertices = [(point.x(), point.y()) for point in geometry.vertices()]
     return {frozenset(line) for line in zip(vertices, vertices[1:])}
 
 

--- a/src/segment_reshape/utils/__init__.py
+++ b/src/segment_reshape/utils/__init__.py
@@ -17,18 +17,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Union
+from segment_reshape.utils.geometry_utils import clone_geometry_safely, vertices
 
-from qgis.core import QgsAbstractGeometry, QgsGeometry
-
-
-def clone_geometry_safely(
-    geometry: Union[QgsGeometry, QgsAbstractGeometry]
-) -> QgsGeometry:
-    if isinstance(geometry, QgsGeometry):
-        original_abstract_geometry = geometry.get()
-        cloned_original_abstract_geometry = original_abstract_geometry.clone()
-        return QgsGeometry(cloned_original_abstract_geometry)
-    else:
-        cloned_original_abstract_geometry = geometry.clone()
-        return QgsGeometry(cloned_original_abstract_geometry)
+__all__ = [
+    "clone_geometry_safely",
+    "vertices",
+]

--- a/src/segment_reshape/utils/geometry_utils.py
+++ b/src/segment_reshape/utils/geometry_utils.py
@@ -1,0 +1,49 @@
+#  Copyright (C) 2022 National Land Survey of Finland
+#  (https://www.maanmittauslaitos.fi/en).
+#
+#
+#  This file is part of segment-reshape-qgis-plugin.
+#
+#  segment-reshape-qgis-plugin is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  segment-reshape-qgis-plugin is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+
+
+from typing import Iterator, Tuple, Union
+
+from qgis.core import QgsAbstractGeometry, QgsGeometry, QgsPoint
+
+
+def clone_geometry_safely(
+    geometry: Union[QgsGeometry, QgsAbstractGeometry]
+) -> QgsGeometry:
+    if isinstance(geometry, QgsGeometry):
+        original_abstract_geometry = geometry.get()
+        cloned_original_abstract_geometry = original_abstract_geometry.clone()
+        return QgsGeometry(cloned_original_abstract_geometry)
+    else:
+        cloned_original_abstract_geometry = geometry.clone()
+        return QgsGeometry(cloned_original_abstract_geometry)
+
+
+def vertices(geometry: QgsGeometry) -> Iterator[Tuple[int, QgsPoint]]:
+    """Generator for vertex_ids and vertices of the geometry
+
+    Args:
+        geometry (QgsGeometry): Input geometry
+
+    Yields:
+        Iterator[Tuple[int, QgsPoint]]: Tuple contains vertex_id and vertex point
+    """
+
+    for vertex_id, vertex in enumerate(geometry.vertices()):
+        yield (vertex_id, vertex)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,7 +17,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union
 from unittest.mock import Mock
 
 import pytest
@@ -65,8 +65,13 @@ def memory_layer_factory() -> Callable[[str, QgsWkbTypes.Type], QgsVectorLayer]:
 def preset_features_layer_factory(
     memory_layer_factory: Callable[[str, QgsWkbTypes.Type], QgsVectorLayer]
 ) -> Callable[[str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]]:
-    def _factory(name: str, wkts: List[str]) -> Tuple[QgsVectorLayer, List[QgsFeature]]:
-        geometries = [QgsGeometry.fromWkt(wkt) for wkt in wkts]
+    def _factory(
+        name: str, geoms: List[Union[str, QgsGeometry]]
+    ) -> Tuple[QgsVectorLayer, List[QgsFeature]]:
+        geometries = [
+            QgsGeometry.fromWkt(geom) if isinstance(geom, str) else geom
+            for geom in geoms
+        ]
         layer = memory_layer_factory(name, geometries[0].wkbType())
         features = [
             QgsVectorLayerUtils.createFeature(layer, geom) for geom in geometries

--- a/test/topology/test_find_related.py
+++ b/test/topology/test_find_related.py
@@ -762,7 +762,7 @@ def test_find_related_features_no_results_by_default_if_topological_editing_disa
 
     assert not QgsProject.instance().topologicalEditing()
 
-    results = find_related_features(source_layer, source_feature)
+    results = list(find_related_features(source_layer, source_feature))
 
     assert results == []
 
@@ -874,8 +874,10 @@ def test_find_related_features_finds_features_touching_the_target(
         ],
     )
 
-    results = find_related_features(
-        source_layer, source_feature, candidate_layers=[layer1, layer2, layer3]
+    results = list(
+        find_related_features(
+            source_layer, source_feature, candidate_layers=[layer1, layer2, layer3]
+        )
     )
 
     assert len(results) == 1 + 2 + 2

--- a/test/utils/test_geometry_utils.py
+++ b/test/utils/test_geometry_utils.py
@@ -1,0 +1,68 @@
+import pytest
+from qgis.core import QgsGeometry, QgsPoint
+
+from segment_reshape.utils import vertices
+
+
+@pytest.mark.parametrize(
+    ("wkt", "expected_points"),
+    [
+        ("Point(0 0)", [QgsPoint(0, 0)]),
+        ("MultiPoint(0 0, 1 1)", [QgsPoint(0, 0), QgsPoint(1, 1)]),
+        ("LineString(0 0, 1 0, 2 0)", [QgsPoint(0, 0), QgsPoint(1, 0), QgsPoint(2, 0)]),
+        (
+            "Polygon(( 0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+            [
+                QgsPoint(0, 0),
+                QgsPoint(0, 3),
+                QgsPoint(3, 3),
+                QgsPoint(3, 0),
+                QgsPoint(0, 0),
+                QgsPoint(1, 1),
+                QgsPoint(1, 2),
+                QgsPoint(2, 2),
+                QgsPoint(2, 1),
+                QgsPoint(1, 1),
+            ],
+        ),
+    ],
+)
+def test_vertices_function_returns_expected_points(wkt, expected_points):
+    geometry = QgsGeometry.fromWkt(wkt)
+    for i, (_, point) in enumerate(vertices(geometry)):
+        assert point == expected_points[i]
+
+
+@pytest.mark.parametrize(
+    "wkt",
+    [
+        "Point(0 0)",
+        "MultiPoint(0 0, 1 1)",
+        "LineString(0 0, 1 0, 2 0)",
+        "MultiLineString((0 0, 1 0, 2 0), (3 0, 4 0))",
+        "Polygon(( 0 0, 0 3, 3 3, 3 0, 0 0))",
+        "Polygon(( 0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1))",
+        (
+            "Multipolygon("
+            "(( 0 0, 0 3, 3 3, 3 0, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1)), "
+            "(( 10 0, 10 3, 13 3, 13 0, 10 0), (11 1, 11 2, 12 2, 12 1, 11 1))"
+            ")"
+        ),
+    ],
+    ids=[
+        "point",
+        "multipoint",
+        "linestring",
+        "multilinestring",
+        "simple polygon",
+        "polygon with a hole",
+        "multipolygons with holes",
+    ],
+)
+def test_vertices_function_returns_expected_vertex_ids(wkt: str):
+    """Tests that our vertices function has same logic for vertex_id:s than qgis"""
+
+    geometry = QgsGeometry.fromWkt(wkt)
+    for vertex_id, point in vertices(geometry):
+        expected_point = geometry.vertexAt(vertex_id)
+        assert point == expected_point


### PR DESCRIPTION
## Description
Performance optimization was done mostly to two functions:
- `find_related_features()`: Filter first by geometry bounding box to get intersect candidates and then do the actual intersection test. Use prepared geometry for intersection testing.
- `_find_vertex_indices()`: Before, a lookup for the vertex_id to the geometry was done for every segment vertex. If the segment had many vertices this was quite costly. Now the geometry is looped only once and vertex_ids are "cached" for every point.

These two changes decreased the finding time for common segment in example case from 32s to 0.7s.

Adds also a wait cursor when segment reshape in progress to make it clear to user.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Other - Performance tuning

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
