### PR TITLE
fix: add support for reshaping closed linestrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: add support for reshaping closed linestrings
+
 ## [0.1.4] - 2023-04-14
 
 - Feature: Change the mouse cursor to the wait cursor when finding common segment os editing is in progress

--- a/src/segment_reshape/geometry/reshape.py
+++ b/src/segment_reshape/geometry/reshape.py
@@ -194,6 +194,23 @@ def _reshape_geometry(
             and vertex_indices[0] == vertex_indices[-1]
         ):
             vertex_indices = vertex_indices[:-1]
+        # handle case when a full line is redrawn as closed
+        elif (
+            len(vertex_indices) > 1
+            and original.type() == QgsWkbTypes.GeometryType.LineGeometry
+            and reshape_geometry.endPoint() == reshape_geometry.startPoint()
+            and vertex_indices[0] == vertex_indices[-1]
+        ):
+            vertex_indices = vertex_indices[1:]
+            reshape_geometry = QgsLineString(list(reshape_geometry.vertices())[1:])
+        # handle case when a full line is redrawn but not closed
+        elif (
+            len(vertex_indices) > 1
+            and original.type() == QgsWkbTypes.GeometryType.LineGeometry
+            and reshape_geometry.endPoint() != reshape_geometry.startPoint()
+            and vertex_indices[0] == vertex_indices[-1]
+        ):
+            vertex_indices = vertex_indices[1:]
 
         # add vertices before the first replaced vertex
         min_vertex_index = min(vertex_indices)

--- a/test/geometry/test_reshape.py
+++ b/test/geometry/test_reshape.py
@@ -730,6 +730,26 @@ def test_edge_lines_moved_to_match_reshape(
     _assert_layer_geoms(layer1, ["LINESTRING(0 0, 2 0)", "LINESTRING(0 2, 4 4)"])
 
 
+def test_closed_line_moved_to_match_reshape(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+):
+    layer1, features1 = preset_features_layer_factory(
+        "l1", ["LINESTRING(0 0, 1 1, 3 3, 0 0)"]
+    )
+
+    make_reshape_edits(
+        [],
+        [
+            ReshapeEdge(layer1, features1[0], 1, is_start=False),
+        ],
+        QgsLineString([(2, 2)]),
+    )
+
+    _assert_layer_geoms(layer1, ["LINESTRING(0 0, 2 2, 3 3, 0 0)"])
+
+
 def test_edge_polygons_moved_to_match_reshape(
     preset_features_layer_factory: Callable[
         [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
@@ -1030,3 +1050,24 @@ def test_full_polygon_partially_replaced_by_reshape_auto_closed(
     )
 
     _assert_layer_geoms(layer1, ["POLYGON((1 1, 1 2, 2 2, 2 1, 1 1))"])
+
+
+def test_closed_line_fully_replaced_by_reshape(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+):
+    layer1, features1 = preset_features_layer_factory(
+        "l1",
+        ["LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"],
+    )
+
+    make_reshape_edits(
+        [
+            ReshapeCommonPart(layer1, features1[0], [0, 1, 2, 3, 4], False),
+        ],
+        [],
+        QgsLineString([(2, 2), (0, 2), (3, 3), (2, 0), (2, 2)]),
+    )
+
+    _assert_layer_geoms(layer1, ["LINESTRING(2 2, 0 2, 3 3, 2 0, 2 2)"])


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Add support for reshaping closed linestrings.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
