### PR TITLE
Fix issues with closed linestrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix: add support for reshaping closed linestrings
+- Fix: Add support for reshaping closed linestrings
+- Fix: Add support for reshaping closed linestring partially, when the reshaped segment falls on the wraparound location
 
 ## [0.1.4] - 2023-04-14
 

--- a/test/geometry/test_reshape.py
+++ b/test/geometry/test_reshape.py
@@ -1071,3 +1071,41 @@ def test_closed_line_fully_replaced_by_reshape(
     )
 
     _assert_layer_geoms(layer1, ["LINESTRING(2 2, 0 2, 3 3, 2 0, 2 2)"])
+
+
+@pytest.mark.parametrize(
+    argnames=("indices", "reshape_wkt"),
+    argvalues=[
+        ([0, 1, 2, 3, 4], "LINESTRING(2 2, 0 2, 3 3, 2 0, 2 2)"),
+        ([4, 1, 2, 3, 4], "LINESTRING(2 2, 0 2, 3 3, 2 0, 2 2)"),
+        ([2, 3, 4, 1, 2], "LINESTRING(3 3, 2 0, 2 2, 0 2, 3 3)"),
+    ],
+    ids=[
+        "wraparound-at-origin-no-duplicate",
+        "wraparound-at-origin-duplicate-last",
+        "wraparound-at-middle",
+    ],
+)
+def test_closed_line_not_drawn_closed_still_closed_by_reshape(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    indices: List[int],
+    reshape_wkt: str,
+):
+    layer1, features1 = preset_features_layer_factory(
+        "l1",
+        ["LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"],
+    )
+
+    reshape_geom = QgsGeometry.fromWkt(reshape_wkt).constGet()
+
+    make_reshape_edits(
+        [
+            ReshapeCommonPart(layer1, features1[0], indices, False),
+        ],
+        [],
+        reshape_geom,
+    )
+
+    _assert_layer_geoms(layer1, [reshape_wkt])

--- a/test/geometry/test_reshape.py
+++ b/test/geometry/test_reshape.py
@@ -1093,22 +1093,23 @@ def test_closed_line_not_drawn_closed_still_closed_by_reshape(
     indices: List[int],
     reshape_wkt: str,
 ):
-    layer1, features1 = preset_features_layer_factory(
+    layer, (feature,) = preset_features_layer_factory(
         "l1",
         ["LINESTRING(0 0, 0 1, 1 1, 1 0, 0 0)"],
     )
 
-    reshape_geom = QgsGeometry.fromWkt(reshape_wkt).constGet()
+    reshape_geom = QgsLineString()
+    assert reshape_geom.fromWkt(reshape_wkt)
 
     make_reshape_edits(
         [
-            ReshapeCommonPart(layer1, features1[0], indices, False),
+            ReshapeCommonPart(layer, feature, indices, False),
         ],
         [],
         reshape_geom,
     )
 
-    _assert_layer_geoms(layer1, [reshape_wkt])
+    _assert_layer_geoms(layer, [reshape_wkt])
 
 
 @pytest.mark.parametrize(
@@ -1160,7 +1161,8 @@ def test_wraparound_closed_linestring_partially_reshaped(
         [original],
     )
 
-    reshape_geom = QgsGeometry.fromWkt(reshape).constGet()
+    reshape_geom = QgsLineString()
+    assert reshape_geom.fromWkt(reshape)
 
     make_reshape_edits(
         [

--- a/test/integration/test_polygon_border_reshaped.py
+++ b/test/integration/test_polygon_border_reshaped.py
@@ -1,0 +1,149 @@
+#  Copyright (C) 2022 National Land Survey of Finland
+#  (https://www.maanmittauslaitos.fi/en).
+#
+#
+#  This file is part of segment-reshape-qgis-plugin.
+#
+#  segment-reshape-qgis-plugin is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  segment-reshape-qgis-plugin is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Callable, List, Tuple
+
+import pytest
+from qgis.core import QgsFeature, QgsGeometry, QgsLineString, QgsProject, QgsVectorLayer
+
+from segment_reshape.geometry.reshape import make_reshape_edits
+from segment_reshape.topology.find_related import find_segment_to_reshape
+
+
+def _normalize_wkt(wkt: str) -> str:
+    g = QgsGeometry.fromWkt(wkt)
+    g.normalize()
+    return g.asWkt()
+
+
+def _assert_layer_geoms(layer: QgsVectorLayer, expected_geom_wkts: List[str]):
+    __tracebackhide__ = True
+
+    layer_wkts = [_normalize_wkt(f.geometry().asWkt()) for f in layer.getFeatures()]
+    expected_wkts = [_normalize_wkt(wkt) for wkt in expected_geom_wkts]
+
+    assert layer_wkts == expected_wkts
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+def test_two_equal_polygons_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+):
+    layer, (first,) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0))",
+        ],
+    )
+    other_layer, _ = preset_features_layer_factory(
+        "l2",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0))",
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer, other_layer])
+
+    _, common_parts, edges = find_segment_to_reshape(
+        layer,
+        first,
+        (0, 1),
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",
+        ],
+    )
+    _assert_layer_geoms(
+        other_layer,
+        [
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "border"],
+    ids=["base-edited", "border-edited"],
+)
+def test_polygon_bordered_by_closed_linestring_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, (base,) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((10 10, 10 20, 20 20, 20 10, 10 10))",
+        ],
+    )
+    other_layer, (border,) = preset_features_layer_factory(
+        "l2",
+        [
+            "LINESTRING(10 10, 10 20, 20 20, 20 10, 10 10)",
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer, other_layer])
+
+    edited_layer = {"base": layer, "border": other_layer}[edited_feature_name]
+    edited_feature = {"base": base, "border": border}[edited_feature_name]
+    edited_indices = {"base": (0, 1), "border": (0, 1)}[edited_feature_name]
+
+    _, common_parts, edges = find_segment_to_reshape(
+        edited_layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",
+        ],
+    )
+    _assert_layer_geoms(
+        other_layer,
+        [
+            "LINESTRING(11 11, 11 19, 19 19, 19 11, 11 11)",
+        ],
+    )

--- a/test/integration/test_polygon_hole_reshaped.py
+++ b/test/integration/test_polygon_hole_reshaped.py
@@ -1,0 +1,397 @@
+#  Copyright (C) 2022 National Land Survey of Finland
+#  (https://www.maanmittauslaitos.fi/en).
+#
+#
+#  This file is part of segment-reshape-qgis-plugin.
+#
+#  segment-reshape-qgis-plugin is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  segment-reshape-qgis-plugin is distributed in the hope that it will be
+#  useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#  of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with segment-reshape-qgis-plugin. If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Callable, List, Tuple
+
+import pytest
+from qgis.core import QgsFeature, QgsGeometry, QgsLineString, QgsProject, QgsVectorLayer
+
+from segment_reshape.geometry.reshape import make_reshape_edits
+from segment_reshape.topology.find_related import find_segment_to_reshape
+
+
+def _normalize_wkt(wkt: str) -> str:
+    g = QgsGeometry.fromWkt(wkt)
+    g.normalize()
+    return g.asWkt()
+
+
+def _assert_layer_geoms(layer: QgsVectorLayer, expected_geom_wkts: List[str]):
+    __tracebackhide__ = True
+
+    layer_wkts = [_normalize_wkt(f.geometry().asWkt()) for f in layer.getFeatures()]
+    expected_wkts = [_normalize_wkt(wkt) for wkt in expected_geom_wkts]
+
+    assert layer_wkts == expected_wkts
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole"],
+    ids=["base-edited", "hole-edited"],
+)
+def test_polygon_hole_filled_with_other_polygon_same_layer_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, features = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+            "POLYGON((10 10, 10 20, 20 20, 20 10, 10 10))",  # hole filled by polygon
+        ],
+    )
+
+    edited_feature = {"base": features[0], "hole": features[1]}[edited_feature_name]
+    edited_indices = {"base": (5, 6), "hole": (0, 1)}[edited_feature_name]
+
+    QgsProject.instance().addMapLayer(layer)
+
+    _, common_parts, edges = find_segment_to_reshape(
+        layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 19 11, 11 11))",  # base
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",  # hole filled by polygon
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole"],
+    ids=["base-edited", "hole-edited"],
+)
+def test_polygon_hole_filled_with_other_polygon_other_layer_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, (base,) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+        ],
+    )
+    other_layer, (hole,) = preset_features_layer_factory(
+        "l2",
+        [
+            "POLYGON((10 10, 10 20, 20 20, 20 10, 10 10))",  # hole filled by polygon
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer, other_layer])
+
+    edited_layer = {"base": layer, "hole": other_layer}[edited_feature_name]
+    edited_feature = {"base": base, "hole": hole}[edited_feature_name]
+    edited_indices = {"base": (5, 6), "hole": (0, 1)}[edited_feature_name]
+
+    _, common_parts, edges = find_segment_to_reshape(
+        edited_layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 19 11, 11 11))",  # base
+        ],
+    )
+    _assert_layer_geoms(
+        other_layer,
+        [
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",  # hole filled by polygon
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole"],
+    ids=["base-edited", "hole-edited"],
+)
+def test_polygon_hole_filled_with_closed_linestring_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, (base,) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+        ],
+    )
+    other_layer, (hole,) = preset_features_layer_factory(
+        "l2",
+        [
+            "LINESTRING(10 10, 10 20, 20 20, 20 10, 10 10)",  # hole filled by closed line
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer, other_layer])
+
+    edited_layer = {"base": layer, "hole": other_layer}[edited_feature_name]
+    edited_feature = {"base": base, "hole": hole}[edited_feature_name]
+    edited_indices = {"base": (5, 6), "hole": (0, 1)}[edited_feature_name]
+
+    _, common_parts, edges = find_segment_to_reshape(
+        edited_layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 19 11, 11 11))",  # base
+        ],
+    )
+    _assert_layer_geoms(
+        other_layer,
+        [
+            "LINESTRING(11 11, 11 19, 19 19, 19 11, 11 11)",  # hole filled closed line
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole1", "hole2", "hole3"],
+    ids=[
+        "base-edited",
+        "same-layer-hole-edited",
+        "other-layer-hole-edited",
+        "other-layer-line-edited",
+    ],
+)
+def test_polygon_hole_filled_by_multiple_features_all_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer1, (base, hole1) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+            "POLYGON((10 10, 10 20, 20 20, 20 10, 10 10))",  # hole filled by polygon
+        ],
+    )
+    layer2, (hole2,) = preset_features_layer_factory(
+        "l2",
+        [
+            "POLYGON((10 10, 10 20, 20 20, 20 10, 10 10))",  # hole filled by polygon
+        ],
+    )
+    layer3, (hole3,) = preset_features_layer_factory(
+        "l3",
+        [
+            "LINESTRING(10 10, 10 20, 20 20, 20 10, 10 10)",  # hole filled by closed line
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer1, layer2, layer3])
+
+    edited_layer = {"base": layer1, "hole1": layer1, "hole2": layer2, "hole3": layer3}[
+        edited_feature_name
+    ]
+    edited_feature = {"base": base, "hole1": hole1, "hole2": hole2, "hole3": hole3}[
+        edited_feature_name
+    ]
+    edited_indices = {
+        "base": (5, 6),
+        "hole1": (0, 1),
+        "hole2": (0, 1),
+        "hole3": (0, 1),
+    }[edited_feature_name]
+
+    _, common_parts, edges = find_segment_to_reshape(
+        edited_layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString(
+            [(11.0, 11.0), (11.0, 19.0), (19.0, 19.0), (19.0, 11.0), (11.0, 11.0)]
+        ),
+    )
+
+    _assert_layer_geoms(
+        layer1,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 19 11, 11 11))",  # base
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",  # hole filled by polygon
+        ],
+    )
+    _assert_layer_geoms(
+        layer2,
+        [
+            "POLYGON((11 11, 11 19, 19 19, 19 11, 11 11))",  # hole filled by polygon
+        ],
+    )
+    _assert_layer_geoms(
+        layer3,
+        [
+            "LINESTRING(11 11, 11 19, 19 19, 19 11, 11 11)",  # hole filled closed line
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole"],
+    ids=["base-edited", "hole-edited"],
+)
+def test_polygon_hole_filled_partially_with_other_polygon_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, features = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+            "POLYGON((10 10, 10 20, 20 20, 10 10))",  # hole partially filled by polygon
+        ],
+    )
+
+    edited_feature = {"base": features[0], "hole": features[1]}[edited_feature_name]
+    edited_indices = {"base": (5, 6), "hole": (0, 1)}[edited_feature_name]
+
+    QgsProject.instance().addMapLayer(layer)
+
+    _, common_parts, edges = find_segment_to_reshape(
+        layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString([(11.0, 11.0), (11.0, 19.0), (19.0, 19.0)]),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 20 10, 11 11))",  # base
+            "POLYGON((11 11, 11 19, 19 19, 11 11))",  # hole filled by polygon
+        ],
+    )
+
+
+@pytest.mark.usefixtures("qgis_new_project", "use_topological_editing")
+@pytest.mark.parametrize(
+    argnames="edited_feature_name",
+    argvalues=["base", "hole"],
+    ids=["base-edited", "hole-edited"],
+)
+def test_polygon_hole_bordered_partially_with_linestring_both_reshaped(
+    preset_features_layer_factory: Callable[
+        [str, List[str]], Tuple[QgsVectorLayer, List[QgsFeature]]
+    ],
+    edited_feature_name: str,
+):
+    layer, (base,) = preset_features_layer_factory(
+        "l1",
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (10 10, 10 20, 20 20, 20 10, 10 10))",  # base
+        ],
+    )
+    other_layer, (hole,) = preset_features_layer_factory(
+        "l2",
+        [
+            "LINESTRING(10 10, 10 20, 20 20)",  # hole partially bordered by line
+        ],
+    )
+
+    QgsProject.instance().addMapLayers([layer, other_layer])
+
+    edited_layer = {"base": layer, "hole": other_layer}[edited_feature_name]
+    edited_feature = {"base": base, "hole": hole}[edited_feature_name]
+    edited_indices = {"base": (5, 6), "hole": (0, 1)}[edited_feature_name]
+
+    _, common_parts, edges = find_segment_to_reshape(
+        edited_layer,
+        edited_feature,
+        edited_indices,
+    )
+
+    make_reshape_edits(
+        common_parts,
+        edges,
+        QgsLineString([(11.0, 11.0), (11.0, 19.0), (19.0, 19.0)]),
+    )
+
+    _assert_layer_geoms(
+        layer,
+        [
+            "POLYGON((0 0, 0 100, 100 100, 100 0, 0 0), (11 11, 11 19, 19 19, 20 10, 11 11))",  # base
+        ],
+    )
+    _assert_layer_geoms(
+        other_layer,
+        [
+            "LINESTRING(11 11, 11 19, 19 19)",  # hole filled closed line
+        ],
+    )


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Fix reshape issues for closed linestrings in polygon holes.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other

- [X] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
