### PR TITLE
fix: move vertex only if its position changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: Edit edge layers only if the edge position changes
+
 ## [0.1.8] - 2025-01-08
 
 - Chore: Fix releasing pipeline

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,6 +32,10 @@ from qgis.core import (
     QgsWkbTypes,
 )
 from qgis.gui import QgisInterface, QgsAdvancedDigitizingDockWidget
+from segment_reshape.geometry.reshape import (
+    _current_edit_command_layers,
+    _set_editable_layer_ids,
+)
 
 
 @pytest.fixture(scope="session")
@@ -80,3 +84,16 @@ def preset_features_layer_factory(
         return layer, added_features
 
     return _factory
+
+
+@pytest.fixture()
+def _with_editable_layers():
+    set_editable_ids: set[str] = set()
+    layers: list[QgsVectorLayer] = []
+    editable_ids_token = _set_editable_layer_ids.set(set_editable_ids)
+    token = _current_edit_command_layers.set(layers)
+    try:
+        yield
+    finally:
+        _current_edit_command_layers.reset(token)
+        _set_editable_layer_ids.reset(editable_ids_token)


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Move vertex only if its position changes.

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Other

- [X] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [X] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
