### PR TITLE
Allow configuring candidate layers for common segments

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: "3.9"
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           pip install . --no-deps
       - run: |
           qgis-plugin-dev-tools build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: plugin-zip
           path: dist/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+- Feature: Use visible vector layers as candidate layers in map tool usage
 - Feature: Add support for configuring candidate layers for common segments
 
 ## Unreleased

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Feature: Add support for configuring candidate layers for common segments
+
 ## Unreleased
 
 ## [0.1.9] - 2025-01-16

--- a/src/segment_reshape/map_tool/segment_reshape_tool.py
+++ b/src/segment_reshape/map_tool/segment_reshape_tool.py
@@ -332,8 +332,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
     def find_common_segment_at_location(
         location: QgsPointXY,
         identify_tool: Optional[QgsMapToolIdentify] = None,
-        # option here to configure the layers
-        # candidate_layers: Optional[List[QgsVectorLayer]] = None,
+        candidate_layers: Optional[list[QgsVectorLayer]] = None,
     ) -> Optional[find_related.CommonGeometriesResult]:
         with _optional_identify_tool(identify_tool) as tool:
             identify_results = tool.identify(
@@ -357,7 +356,6 @@ class SegmentReshapeTool(QgsMapToolCapture):
             _,
         ) = feature.geometry().closestSegmentWithContext(location)
 
-        # pass option here
         return find_related.find_segment_to_reshape(
-            layer, feature, (next_vertex_index - 1, next_vertex_index), # candidate_layers
+            layer, feature, (next_vertex_index - 1, next_vertex_index), candidate_layers
         )

--- a/src/segment_reshape/map_tool/segment_reshape_tool.py
+++ b/src/segment_reshape/map_tool/segment_reshape_tool.py
@@ -311,8 +311,11 @@ class SegmentReshapeTool(QgsMapToolCapture):
             MsgBar.warning(tr("No active layer found"), tr("Activate a layer first"))
             return None, None
 
+        # for map tool purposes the default behaviour of all layers (in find_related) is too broad
+        # candidate_layers = [all visible project vector layers, ...]
+
         results = SegmentReshapeTool.find_common_segment_at_location(
-            location, self._identify_tool
+            location, self._identify_tool, # candidate_layers
         )
 
         if results is None:
@@ -327,7 +330,10 @@ class SegmentReshapeTool(QgsMapToolCapture):
 
     @staticmethod
     def find_common_segment_at_location(
-        location: QgsPointXY, identify_tool: Optional[QgsMapToolIdentify] = None
+        location: QgsPointXY,
+        identify_tool: Optional[QgsMapToolIdentify] = None,
+        # option here to configure the layers
+        # candidate_layers: Optional[List[QgsVectorLayer]] = None,
     ) -> Optional[find_related.CommonGeometriesResult]:
         with _optional_identify_tool(identify_tool) as tool:
             identify_results = tool.identify(
@@ -351,6 +357,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
             _,
         ) = feature.geometry().closestSegmentWithContext(location)
 
+        # pass option here
         return find_related.find_segment_to_reshape(
-            layer, feature, (next_vertex_index - 1, next_vertex_index)
+            layer, feature, (next_vertex_index - 1, next_vertex_index), # candidate_layers
         )


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This pr:
- Adds feature to allow configuring candidate layers for common segments
- Uses visible vector layers as candidate layers for map tool usage

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
