### PR TITLE
WIP: chore: add support for qt6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Chore: Add qt6 and QGIS 4 support
+
 ## [0.1.10] - 2025-06-19
 
 - Feature: Use visible vector layers as candidate layers in map tool usage

--- a/src/segment_reshape/map_tool/segment_reshape_tool.py
+++ b/src/segment_reshape/map_tool/segment_reshape_tool.py
@@ -155,7 +155,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
 
     def _change_to_pick_location_mode(self) -> None:
         self._tool_mode = ToolMode.PICK_SEGMENT
-        self.setCursor(Qt.CrossCursor)
+        self.setCursor(Qt.CursorShape.CrossCursor)
         self.setAutoSnapEnabled(False)
         self.setAdvancedDigitizingAllowed(False)
 
@@ -188,10 +188,10 @@ class SegmentReshapeTool(QgsMapToolCapture):
         point_count = self.size()
         super().keyPressEvent(key_event)  # handle normal undo and cancel procedures
         if self._tool_mode == ToolMode.RESHAPE:
-            if key_event.key() == Qt.Key_Escape:
+            if key_event.key() == Qt.Key.Key_Escape:
                 self._change_to_pick_location_mode()
             elif (
-                key_event.key() in (Qt.Key_Delete, Qt.Key_Backspace)
+                key_event.key() in (Qt.Key.Key_Delete, Qt.Key.Key_Backspace)
                 and point_count == 1
             ):
                 # self.undo() resists to undo the first point so force back to initial
@@ -219,7 +219,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
     @log_if_fails
     def canvasReleaseEvent(self, mouse_event: QgsMapMouseEvent) -> None:  # noqa: N802
         if self._tool_mode == ToolMode.PICK_SEGMENT:
-            if mouse_event.button() == Qt.LeftButton:
+            if mouse_event.button() == Qt.MouseButton.LeftButton:
                 self._handle_pick_segment_left_click(mouse_event.mapPoint())
             return
         super().canvasReleaseEvent(mouse_event)
@@ -238,7 +238,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
         """
 
         if self._tool_mode == ToolMode.RESHAPE:
-            if mouse_event.button() == Qt.LeftButton:
+            if mouse_event.button() == Qt.MouseButton.LeftButton:
                 result = self.addVertex(
                     mouse_event.mapPoint(), mouse_event.mapPointMatch()
                 )
@@ -248,7 +248,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
                     )
                     return
                 self.startCapturing()
-            elif mouse_event.button() == Qt.RightButton:
+            elif mouse_event.button() == Qt.MouseButton.RightButton:
                 self._handle_reshape_right_click()
 
     def cadCanvasMoveEvent(self, mouse_event: QgsMapMouseEvent) -> None:  # noqa: N802
@@ -257,7 +257,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
         return super().cadCanvasMoveEvent(mouse_event)
 
     def _handle_pick_segment_left_click(self, location: QgsPointXY) -> None:
-        with override_cursor(Qt.WaitCursor):
+        with override_cursor(Qt.CursorShape.WaitCursor):
             common_segment, layer = self._find_common_segment(location)
             # No active layer or active layer feature found
             if layer is None:
@@ -280,7 +280,7 @@ class SegmentReshapeTool(QgsMapToolCapture):
             self._change_to_reshape_mode_for_geom(QgsGeometry(common_segment), layer)
 
     def _handle_reshape_right_click(self) -> None:
-        with override_cursor(Qt.WaitCursor):
+        with override_cursor(Qt.CursorShape.WaitCursor):
             new_geometry = self.captureCurve().curveToLine()
             self.stopCapturing()
 

--- a/src/segment_reshape_plugin/metadata.txt
+++ b/src/segment_reshape_plugin/metadata.txt
@@ -28,3 +28,4 @@ experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version)
 deprecated=False
+supportsQt6=True

--- a/test/map_tool/test_segment_reshape_tool.py
+++ b/test/map_tool/test_segment_reshape_tool.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
             self,
             location: QgsPointXY,
             mouse_event_type: QEvent.Type,
-            mouse_button: Optional[Qt.MouseButton] = Qt.NoButton,
+            mouse_button: Optional[Qt.MouseButton] = Qt.MouseButton.NoButton,
         ) -> QgsMapMouseEvent:
             ...
 
@@ -64,7 +64,7 @@ def mouse_event_factory(
         mouse_event_type: QEvent.Type,
         mouse_button: Optional[Qt.MouseButton] = None,
     ) -> QgsMapMouseEvent:
-        mouse_button = mouse_button or Qt.NoButton
+        mouse_button = mouse_button or Qt.MouseButton.NoButton
         event = QgsMapMouseEvent(
             qgis_canvas,
             mouse_event_type,
@@ -131,7 +131,9 @@ def test_pressing_esc_in_reshape_mode_aborts_reshape(map_tool: SegmentReshapeToo
     )
     assert map_tool._tool_mode == ToolMode.RESHAPE
 
-    escape_press = QKeyEvent(QEvent.KeyPress, Qt.Key_Escape, Qt.NoModifier)
+    escape_press = QKeyEvent(
+        QEvent.Type.KeyPress, Qt.Key.Key_Escape, Qt.KeyboardModifier.NoModifier
+    )
     map_tool.keyPressEvent(escape_press)
 
     assert map_tool._tool_mode == ToolMode.PICK_SEGMENT
@@ -162,8 +164,8 @@ def test_left_mouse_click_in_pick_mode_does_nothing_if_active_layer_or_feature_n
 
     map_release = mouse_event_factory(
         MOUSE_LOCATION,
-        QEvent.MouseButtonRelease,
-        Qt.LeftButton,
+        QEvent.Type.MouseButtonRelease,
+        Qt.MouseButton.LeftButton,
     )
     map_tool.canvasReleaseEvent(map_release)
 
@@ -187,8 +189,8 @@ def test_left_mouse_click_in_pick_mode_does_nothing_if_common_segment_not_found(
 
     map_release = mouse_event_factory(
         MOUSE_LOCATION,
-        QEvent.MouseButtonRelease,
-        Qt.LeftButton,
+        QEvent.Type.MouseButtonRelease,
+        Qt.MouseButton.LeftButton,
     )
     map_tool.canvasReleaseEvent(map_release)
 
@@ -215,8 +217,8 @@ def test_left_mouse_click_in_pick_mode_starts_reshape_mode_if_common_segment_is_
 
     map_release = mouse_event_factory(
         MOUSE_LOCATION,
-        QEvent.MouseButtonRelease,
-        Qt.LeftButton,
+        QEvent.Type.MouseButtonRelease,
+        Qt.MouseButton.LeftButton,
     )
     map_tool.canvasReleaseEvent(map_release)
 
@@ -251,8 +253,8 @@ def test_left_mouse_click_in_reshape_mode_adds_points_to_maptool(
 
     map_release = mouse_event_factory(
         MOUSE_LOCATION,
-        QEvent.MouseButtonRelease,
-        Qt.LeftButton,
+        QEvent.Type.MouseButtonRelease,
+        Qt.MouseButton.LeftButton,
     )
     map_tool.canvasReleaseEvent(map_release)
 
@@ -296,7 +298,9 @@ def test_undo_add_vertex_should_update_new(
     assert map_tool.captureCurve().curveToLine().asWkt() == "LineString (0 0, 1 1, 2 2)"
 
     # Undo n times
-    undo_key_event = QKeyEvent(QEvent.KeyPress, Qt.Key_Backspace, Qt.NoModifier)
+    undo_key_event = QKeyEvent(
+        QEvent.Type.KeyPress, Qt.Key.Key_Backspace, Qt.KeyboardModifier.NoModifier
+    )
     for _ in range(points_to_remove):
         map_tool.keyPressEvent(undo_key_event)
 
@@ -316,7 +320,7 @@ def test_start_point_indicator_rubberband(
     map_tool._change_to_reshape_mode_for_geom(old_geom)
 
     # Move cursor to move temp rubberband end point
-    mouse_move_event = mouse_event_factory(QgsPointXY(2, 3), QEvent.MouseMove)
+    mouse_move_event = mouse_event_factory(QgsPointXY(2, 3), QEvent.Type.MouseMove)
     map_tool.canvasMoveEvent(mouse_move_event)
 
     assert map_tool.start_point_indicator_rubber_band.isVisible()
@@ -329,10 +333,12 @@ def test_start_point_indicator_rubberband(
 
     assert not map_tool.start_point_indicator_rubber_band.isVisible()
 
-    undo_key_event = QKeyEvent(QEvent.KeyPress, Qt.Key_Backspace, Qt.NoModifier)
+    undo_key_event = QKeyEvent(
+        QEvent.Type.KeyPress, Qt.Key.Key_Backspace, Qt.KeyboardModifier.NoModifier
+    )
     map_tool.keyPressEvent(undo_key_event)
 
-    mouse_move_event = mouse_event_factory(QgsPointXY(4, 3), QEvent.MouseMove)
+    mouse_move_event = mouse_event_factory(QgsPointXY(4, 3), QEvent.Type.MouseMove)
     map_tool.canvasMoveEvent(mouse_move_event)
     assert map_tool.start_point_indicator_rubber_band.isVisible()
     assert (
@@ -358,7 +364,7 @@ def test_right_mouse_click_in_reshape_mode_changes_only_to_pick_mode_if_edited_g
     )
 
     right_click = mouse_event_factory(
-        QgsPointXY(1, 1), QEvent.MouseButtonRelease, Qt.RightButton
+        QgsPointXY(1, 1), QEvent.Type.MouseButtonRelease, Qt.MouseButton.RightButton
     )
     map_tool.cadCanvasReleaseEvent(right_click)
 
@@ -382,14 +388,14 @@ def test_right_mouse_click_in_reshape_mode_calls_reshape_if_edited_geometry_is_n
     )
 
     left_click = mouse_event_factory(
-        QgsPointXY(1, 1), QEvent.MouseButtonRelease, Qt.LeftButton
+        QgsPointXY(1, 1), QEvent.Type.MouseButtonRelease, Qt.MouseButton.LeftButton
     )
     # Add point to rubberband
     map_tool.canvasReleaseEvent(left_click)
 
     # Test
     right_click = mouse_event_factory(
-        QgsPointXY(1, 1), QEvent.MouseButtonRelease, Qt.RightButton
+        QgsPointXY(1, 1), QEvent.Type.MouseButtonRelease, Qt.MouseButton.RightButton
     )
     map_tool.cadCanvasReleaseEvent(right_click)
 


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

This PR uses official [QGIS migration instructions ](https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6)to add QT6 and QGIS>=4.0 support while being still backwards compatible with QT5 and QGIS 3.x versions.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
