### PR TITLE
Add official support to QGIS 3.44

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       image: qgis/qgis:${{ matrix.qgis-image-tags }}
     strategy:
       matrix:
-        qgis-image-tags: [release-3_22, release-3_28, release-3_34, "3.40"]
+        qgis-image-tags: [release-3_22, release-3_28, release-3_34, "3.44"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Add official support to QGIS 3.44

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/segment-reshape-qgis-plugin/blob/main/CHANGELOG.md
